### PR TITLE
Add cases page for doctors and patients

### DIFF
--- a/templates/cases.html
+++ b/templates/cases.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>All Cases | MediAssist</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <style>
+      body {
+        background: #f8fafc;
+      }
+      .cases-header {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        padding: 2rem;
+        color: white;
+        border-bottom: 2px solid #667eea;
+      }
+      .cases-header h1 {
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+      }
+      .cases-header p {
+        margin: 0;
+        opacity: 0.95;
+      }
+      .table-container {
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        overflow: hidden;
+      }
+      .table {
+        margin-bottom: 0;
+      }
+      .table thead {
+        background: #f3f4f6;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.85rem;
+        letter-spacing: 0.5px;
+      }
+      .table tbody tr {
+        border-bottom: 1px solid #e5e7eb;
+        transition: background-color 0.2s ease;
+      }
+      .table tbody tr:hover {
+        background-color: #f9fafb;
+      }
+      .case-date {
+        font-weight: 500;
+        color: #1f2937;
+      }
+      .case-link {
+        color: #667eea;
+        text-decoration: none;
+        font-weight: 500;
+        transition: color 0.2s ease;
+      }
+      .case-link:hover {
+        color: #764ba2;
+        text-decoration: underline;
+      }
+      .status-badge {
+        display: inline-block;
+        padding: 0.4rem 0.8rem;
+        border-radius: 50px;
+        font-size: 0.8rem;
+        font-weight: 600;
+      }
+      .status-pending {
+        background: #fef3c7;
+        color: #92400e;
+      }
+      .status-completed {
+        background: #d1fae5;
+        color: #065f46;
+      }
+      .status-reviewed {
+        background: #dbeafe;
+        color: #0c2d6b;
+      }
+      .empty-state {
+        text-align: center;
+        padding: 3rem 2rem;
+        color: #6b7280;
+      }
+      .empty-state i {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+        color: #d1d5db;
+      }
+      .empty-state h5 {
+        color: #374151;
+        margin-bottom: 0.5rem;
+      }
+      .btn-back {
+        margin-bottom: 2rem;
+      }
+      .cases-count {
+        background: rgba(255, 255, 255, 0.2);
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        border-radius: 50px;
+        font-size: 0.9rem;
+        margin-top: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- NAVBAR -->
+    <nav class="navbar navbar-dark bg-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">
+          <i class="fas fa-hospital-user me-2"></i>MediAssist
+        </a>
+        <div class="d-flex align-items-center gap-3">
+          {% if role == 'doctor' %}
+          <a href="/doctor/dashboard" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-home me-1"></i>Dashboard
+          </a>
+          <a href="/doctor/logout" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-sign-out-alt me-1"></i>Logout
+          </a>
+          {% else %}
+          <a href="/patient/intake" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-home me-1"></i>Home
+          </a>
+          <a href="/patient/intake" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-plus me-1"></i>Add Case
+          </a>
+          <a href="/patient/logout" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-sign-out-alt me-1"></i>Logout
+          </a>
+          {% endif %}
+        </div>
+      </div>
+    </nav>
+
+    <!-- HEADER -->
+    <div class="cases-header">
+      <div class="container-fluid">
+        <h1>
+          <i class="fas fa-folder-open me-2"></i>
+          {% if role == 'doctor' %} Your Assigned Cases {% else %} Your Health
+          Records {% endif %}
+        </h1>
+        <p>
+          {% if role == 'doctor' %} View all patient cases assigned to you {%
+          else %} View all your clinical cases and consultations {% endif %}
+        </p>
+        <div class="cases-count">
+          <i class="fas fa-briefcase-medical me-1"></i>
+          {{ cases|length }} Case{% if cases|length != 1 %}s{% endif %}
+        </div>
+      </div>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div class="container-fluid my-5">
+      {% if cases %}
+      <div class="table-container">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th><i class="fas fa-calendar me-2"></i>Date</th>
+              <th><i class="fas fa-user-circle me-2"></i>Patient Name</th>
+              <th><i class="fas fa-user-md me-2"></i>Doctor Name</th>
+              <th><i class="fas fa-info-circle me-2"></i>Status</th>
+              <th><i class="fas fa-external-link-alt me-2"></i>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for case in cases %}
+            <tr>
+              <td class="case-date">
+                {% if case.timestamp %} {{ case.timestamp[:10] }} {% else %} N/A
+                {% endif %}
+              </td>
+              <td>
+                {% if case.raw_data and case.raw_data.patient_name %} {{
+                case.raw_data.patient_name }} {% else %} Unknown Patient {%
+                endif %}
+              </td>
+              <td>
+                {% if case.raw_data and case.raw_data.doctor_name %} {{
+                case.raw_data.doctor_name }} {% else %} Unknown Doctor {% endif
+                %}
+              </td>
+              <td>
+                {% if case.status == "Pending Review" %}
+                <span class="status-badge status-pending">
+                  <i class="fas fa-hourglass-half me-1"></i>{{ case.status }}
+                </span>
+                {% elif case.status == "Completed" %}
+                <span class="status-badge status-completed">
+                  <i class="fas fa-check-circle me-1"></i>{{ case.status }}
+                </span>
+                {% elif case.status == "Reviewed" %}
+                <span class="status-badge status-reviewed">
+                  <i class="fas fa-eye me-1"></i>{{ case.status }}
+                </span>
+                {% else %}
+                <span
+                  class="status-badge"
+                  style="background: #f3f4f6; color: #6b7280"
+                >
+                  {{ case.status }}
+                </span>
+                {% endif %}
+              </td>
+              <td>
+                {% if role == 'doctor' %}
+                <a href="/doctor/view/{{ case.id }}" class="case-link">
+                  <i class="fas fa-eye me-1"></i>View Details
+                </a>
+                {% else %}
+                <a href="/patient/result/{{ case.id }}" class="case-link">
+                  <i class="fas fa-eye me-1"></i>View Summary
+                </a>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="table-container">
+        <div class="empty-state">
+          <i class="fas fa-inbox"></i>
+          <h5>No Cases Found</h5>
+          <p>
+            {% if role == 'doctor' %} You don't have any cases assigned yet.
+            Check back soon! {% else %} You haven't submitted any cases yet.
+            Start by submitting your intake form. {% endif %}
+          </p>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+
+    <!-- FOOTER -->
+    <footer class="bg-light border-top mt-5 py-4">
+      <div class="container-fluid text-center text-muted small">
+        <p class="mb-0">
+          &copy; 2024 MediAssist. Patient privacy is our priority.
+        </p>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/templates/doctor_dashboard.html
+++ b/templates/doctor_dashboard.html
@@ -1,154 +1,188 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Clinical Dashboard | MediAssist</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
     <style>
-        body { background: #f8fafc; }
-        .dashboard-header {
-            background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
-            padding: 2rem;
-            border-bottom: 2px solid #ce93d8;
-        }
-        .doctor-info {
-            color: #0d0b0b;
-            text-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        }
-        .doctor-info h3 {
-            font-weight: 700;
-            margin-bottom: 0.25rem;
-            color: #000000;
-            font-size: 1.75rem;
-        }
-        .doctor-info p {
-            margin: 0;
-            font-size: 1rem;
-            color: #000000;
-        }
-        .stats-badge {
-            background: rgba(255,255,255,0.25);
-            backdrop-filter: blur(10px);
-            padding: 0.75rem 1.5rem;
-            border-radius: 50px;
-            color: #000000;
-            font-weight: 600;
-            border: 1px solid rgba(255,255,255,0.3);
-        }
-        .case-card {
-            transition: all 0.3s ease;
-        }
-        .case-card:hover {
-            box-shadow: 0 8px 16px rgba(0,0,0,0.1);
-            transform: translateY(-2px);
-        }
-        .status-badge {
-            display: inline-block;
-            padding: 0.5rem 1rem;
-            border-radius: 50px;
-            font-size: 0.85rem;
-            font-weight: 600;
-        }
-        .status-ready {
-            background: #fef3c7;
-            color: #92400e;
-        }
+      body {
+        background: #f8fafc;
+      }
+      .dashboard-header {
+        background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
+        padding: 2rem;
+        border-bottom: 2px solid #ce93d8;
+      }
+      .doctor-info {
+        color: #0d0b0b;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      }
+      .doctor-info h3 {
+        font-weight: 700;
+        margin-bottom: 0.25rem;
+        color: #000000;
+        font-size: 1.75rem;
+      }
+      .doctor-info p {
+        margin: 0;
+        font-size: 1rem;
+        color: #000000;
+      }
+      .stats-badge {
+        background: rgba(255, 255, 255, 0.25);
+        backdrop-filter: blur(10px);
+        padding: 0.75rem 1.5rem;
+        border-radius: 50px;
+        color: #000000;
+        font-weight: 600;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+      }
+      .case-card {
+        transition: all 0.3s ease;
+      }
+      .case-card:hover {
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+        transform: translateY(-2px);
+      }
+      .status-badge {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        border-radius: 50px;
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      .status-ready {
+        background: #fef3c7;
+        color: #92400e;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <!-- NAVBAR -->
     <nav class="navbar navbar-dark bg-dark">
-        <div class="container-fluid">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-hospital-user me-2"></i>MediAssist Provider Portal
-            </a>
-            <div class="d-flex align-items-center gap-3">
-                <span class="text-light">{{ doctor.name }}</span>
-                <a href="/doctor/logout" class="btn btn-outline-light btn-sm">
-                    <i class="fas fa-sign-out-alt me-1"></i>Logout
-                </a>
-            </div>
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">
+          <i class="fas fa-hospital-user me-2"></i>MediAssist Provider Portal
+        </a>
+        <div class="d-flex align-items-center gap-3">
+          <a href="/cases" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-folder-open me-1"></i>All Cases
+          </a>
+          <span class="text-light">{{ doctor.name }}</span>
+          <a href="/doctor/logout" class="btn btn-outline-light btn-sm">
+            <i class="fas fa-sign-out-alt me-1"></i>Logout
+          </a>
         </div>
+      </div>
     </nav>
 
     <!-- HEADER -->
     <div class="dashboard-header">
-        <div class="container-fluid">
-            <div class="row align-items-center justify-content-between">
-                <div class="col-md-8">
-                    <div class="doctor-info">
-                        <h3><i class="fas fa-user-md me-2"></i>{{ doctor.name }}</h3>
-                        <p><i class="fas fa-stethoscope me-1"></i>{{ doctor.specialty }}</p>
-                    </div>
-                </div>
-                <div class="col-md-4 text-md-end">
-                    <div class="stats-badge">
-                        <i class="fas fa-briefcase-medical me-1"></i>
-                        {{ cases|length }} Active Cases
-                    </div>
-                </div>
+      <div class="container-fluid">
+        <div class="row align-items-center justify-content-between">
+          <div class="col-md-8">
+            <div class="doctor-info">
+              <h3><i class="fas fa-user-md me-2"></i>{{ doctor.name }}</h3>
+              <p>
+                <i class="fas fa-stethoscope me-1"></i>{{ doctor.specialty }}
+              </p>
             </div>
+          </div>
+          <div class="col-md-4 text-md-end">
+            <div class="stats-badge">
+              <i class="fas fa-briefcase-medical me-1"></i>
+              {{ cases|length }} Active Cases
+            </div>
+          </div>
         </div>
+      </div>
     </div>
 
     <!-- MAIN CONTENT -->
     <div class="container-fluid my-5">
-        <div class="mb-4">
-            <h4 class="fw-bold text-dark">Active Triage Queue</h4>
-            <p class="text-muted">Cases assigned to you</p>
-        </div>
+      <div class="mb-4">
+        <h4 class="fw-bold text-dark">Active Triage Queue</h4>
+        <p class="text-muted">Cases assigned to you</p>
+      </div>
 
-        {% if cases %}
-        <div class="card shadow-sm border-0">
-            <div class="table-responsive">
-                <table class="table table-hover mb-0 align-middle">
-                    <thead class="table-light">
-                        <tr>
-                            <th>Case ID</th>
-                            <th>Date/Time</th>
-                            <th>Patient</th>
-                            <th>Chief Complaint</th>
-                            <th>Status</th>
-                            <th>Action</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for case in cases %}
-                        <tr class="case-card">
-                            <td><code class="text-primary fw-bold">{{ case.raw_data.id }}</code></td>
-                            <td>{{ case.raw_data.timestamp }}</td>
-                            <td>
-                                <strong>{{ case.raw_data.name }}</strong><br>
-                                <small class="text-muted">{{ case.raw_data.age }}y / {{ case.raw_data.gender }}</small>
-                            </td>
-                            <td>
-                                <span class="text-truncate d-inline-block" style="max-width: 250px;" title="{{ case.raw_data.symptoms }}">
-                                    {{ case.raw_data.symptoms }}
-                                </span>
-                            </td>
-                            <td><span class="status-badge status-ready"><i class="fas fa-check-circle me-1"></i>Ready</span></td>
-                            <td>
-                                <a href="/doctor/view/{{ case.raw_data.id }}" class="btn btn-sm btn-primary">
-                                    <i class="fas fa-file-medical me-1"></i>View SOAP
-                                </a>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+      {% if cases %}
+      <div class="card shadow-sm border-0">
+        <div class="table-responsive">
+          <table class="table table-hover mb-0 align-middle">
+            <thead class="table-light">
+              <tr>
+                <th>Case ID</th>
+                <th>Date/Time</th>
+                <th>Patient</th>
+                <th>Chief Complaint</th>
+                <th>Status</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for case in cases %}
+              <tr class="case-card">
+                <td>
+                  <code class="text-primary fw-bold"
+                    >{{ case.raw_data.id }}</code
+                  >
+                </td>
+                <td>{{ case.raw_data.timestamp }}</td>
+                <td>
+                  <strong>{{ case.raw_data.name }}</strong><br />
+                  <small class="text-muted"
+                    >{{ case.raw_data.age }}y / {{ case.raw_data.gender
+                    }}</small
+                  >
+                </td>
+                <td>
+                  <span
+                    class="text-truncate d-inline-block"
+                    style="max-width: 250px"
+                    title="{{ case.raw_data.symptoms }}"
+                  >
+                    {{ case.raw_data.symptoms }}
+                  </span>
+                </td>
+                <td>
+                  <span class="status-badge status-ready"
+                    ><i class="fas fa-check-circle me-1"></i>Ready</span
+                  >
+                </td>
+                <td>
+                  <a
+                    href="/doctor/view/{{ case.raw_data.id }}"
+                    class="btn btn-sm btn-primary"
+                  >
+                    <i class="fas fa-file-medical me-1"></i>View SOAP
+                  </a>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-        {% else %}
-        <div class="card shadow-sm border-0 text-center p-5">
-            <i class="fas fa-inbox text-muted" style="font-size: 3rem; margin-bottom: 1rem;"></i>
-            <h5 class="text-muted">No Active Cases</h5>
-            <p class="text-muted">Waiting for patients to submit intake forms...</p>
-        </div>
-        {% endif %}
+      </div>
+      {% else %}
+      <div class="card shadow-sm border-0 text-center p-5">
+        <i
+          class="fas fa-inbox text-muted"
+          style="font-size: 3rem; margin-bottom: 1rem"
+        ></i>
+        <h5 class="text-muted">No Active Cases</h5>
+        <p class="text-muted">Waiting for patients to submit intake forms...</p>
+      </div>
+      {% endif %}
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+  </body>
 </html>

--- a/templates/intake.html
+++ b/templates/intake.html
@@ -1,260 +1,415 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>MediAssist | Patient Intake Form</title>
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
-        .req { color: var(--color-danger); font-weight: bold; }
+      .req {
+        color: var(--color-danger);
+        font-weight: bold;
+      }
     </style>
-</head>
-<body>
-
-<!-- NAVBAR -->
-<nav class="navbar">
-    <div class="container">
+  </head>
+  <body>
+    <!-- NAVBAR -->
+    <nav class="navbar">
+      <div class="container">
         <a class="navbar-brand" href="/">
-            <i class="fas fa-heartbeat"></i>
-            <span>MediAssist <small class="text-muted">Check-In</small></span>
+          <i class="fas fa-heartbeat"></i>
+          <span>MediAssist <small class="text-muted">Check-In</small></span>
         </a>
-        <a href="/patient/logout" class="btn btn-outline-secondary btn-sm">
+        <div class="d-flex gap-2">
+          <a href="/cases" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-folder-open me-1"></i> All Records
+          </a>
+          <a href="/patient/logout" class="btn btn-outline-secondary btn-sm">
             <i class="fas fa-arrow-left me-1"></i> Exit
-        </a>
-    </div>
-</nav>
-
-<!-- MAIN CONTENT -->
-<main class="container my-5">
-    <div class="row justify-content-center">
-        <div class="col-lg-8 col-md-10">
-
-            <!-- HERO -->
-            <div class="hero-section">
-                <h2 id="heroTitle">
-                    <i class="fas fa-clipboard-user me-2"></i>
-                    Begin Your Clinical Check-In
-                </h2>
-                <p id="heroDesc">
-                    This pre-visit intake will help your doctor prepare for your appointment. 
-                    Please answer honestly and thoroughly.
-                </p>
-            </div>
-
-            {% if error %}
-            <div class="alert alert-danger mb-4">{{ error }}</div>
-            {% endif %}
-
-            <!-- LANGUAGE -->
-            <div class="d-flex justify-content-end mb-4">
-                <div style="max-width: 180px;">
-                    <label class="form-label small mb-2">Interface Language:</label>
-                    <select class="form-select form-select-sm" id="languageSelect" onchange="switchLanguage(this.value)">
-                        <option value="English" selected>🇬🇧 English</option>
-                        <option value="Hindi">🇮🇳 हिन्दी (Hindi)</option>
-                    </select>
-                </div>
-            </div>
-
-            <!-- FORM -->
-            <form action="/patient/submit" method="POST" class="form-card" novalidate>
-                <input type="hidden" name="language" id="hiddenLanguage" value="English">
-
-                <div class="row g-3">
-
-                    <!-- DOCTOR -->
-                    <div class="col-12">
-                        <div class="form-row-label" id="sectionDoctor">👨‍⚕️ Select Your Doctor</div>
-                    </div>
-
-                    <div class="col-12">
-                        <label class="form-label" id="lbl_doctor">Which doctor are you visiting? <span class="req">*</span></label>
-                        <select id="selectDoctor" name="doctor_id" class="form-select" required>
-                            <option value="">-- Select a Doctor --</option>
-                            {% for doctor in doctors %}
-                            <option value="{{ doctor.id }}">{{ doctor.name }} - {{ doctor.specialty }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-
-                    <!-- DEMOGRAPHICS -->
-                    <div class="col-12">
-                        <div class="form-row-label" id="sectionDemographics">👤 Personal Information</div>
-                    </div>
-
-                    <div class="col-sm-6">
-                        <label class="form-label" id="lbl_name">Full Name</label>
-                        <input type="text" id="inputName" name="name" class="form-control" placeholder="Enter your full name" required>
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_age">Age <span class="req">*</span></label>
-                        <input type="number" id="inputAge" name="age" class="form-control" min="0" max="150" required>
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_gender">Gender</label>
-                        <select id="selectGender" name="gender" class="form-select">
-                            <option>Female</option>
-                            <option>Male</option>
-                            <option>Other</option>
-                        </select>
-                    </div>
-
-                    <!-- VITALS -->
-                    <div class="col-12 mt-2">
-                        <div class="form-row-label" id="sectionVitals">📊 Vital Signs</div>
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_temp">Temperature (°C)</label>
-                        <input type="number" id="inputTemp" name="temperature" class="form-control" min="30" max="45" step="0.1" placeholder="37.0">
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_bp">Blood Pressure (optional)</label>
-                        <input type="text" id="inputBP" name="blood_pressure" class="form-control" placeholder="e.g. 120/80">
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_weight">Weight (kg)</label>
-                        <input type="number" id="inputWeight" name="weight" class="form-control" min="1" max="500" step="0.1" placeholder="e.g. 70">
-                    </div>
-
-                    <div class="col-sm-3">
-                        <label class="form-label" id="lbl_height">Height (cm)</label>
-                        <input type="number" id="inputHeight" name="height" class="form-control" min="30" max="250" step="0.1" placeholder="e.g. 170">
-                    </div>
-
-                    <!-- MEDICAL -->
-                    <div class="col-12 mt-2">
-                        <div class="form-row-label" id="sectionMedical">⚕️ Medical Information</div>
-                    </div>
-
-                    <div class="col-md-6">
-                        <label class="form-label" id="lbl_allergies">Allergies <span class="req">*</span></label>
-                        <input type="text" id="inputAllergies" name="allergies" class="form-control" required>
-                    </div>
-
-                    <div class="col-md-6">
-                        <label class="form-label" id="lbl_meds">Current Medications <span class="req">*</span></label>
-                        <input type="text" id="inputMeds" name="current_medications" class="form-control" required>
-                    </div>
-
-                    <!-- SYMPTOMS -->
-                    <div class="col-12 mt-2">
-                        <div class="form-row-label" id="sectionComplaint">🏥 Chief Complaint</div>
-                    </div>
-
-                    <div class="col-12">
-                        <label class="form-label" id="lbl_symptoms">Describe Your Symptoms <span class="req">*</span></label>
-                        <textarea id="textSymptoms" name="symptoms" class="form-control" rows="5" required></textarea>
-                    </div>
-
-                    <div class="col-12">
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" value="1" name="confirm" required>
-                            <label class="form-check-label small-muted">I confirm this data is accurate.</label>
-                        </div>
-                    </div>
-
-                    <!-- SUBMIT -->
-                    <div class="col-12 text-center mt-4">
-                        <button type="submit" class="btn-medical w-100">
-                            <i class="fas fa-wand-magic-sparkles me-2"></i>
-                            <span id="btnText">Generate Clinical Summary</span>
-                        </button>
-                    </div>
-                </div>
-            </form>
-
-            {% if error %}
-            <div class="alert alert-danger mt-4">{{ error }}</div>
-            {% endif %}
-
+          </a>
         </div>
-    </div>
-</main>
+      </div>
+    </nav>
 
-<!-- TRANSLATION SCRIPT -->
-<script>
-const TRANSLATIONS = {
-    'Hindi': {
-        'heroTitle': '<i class="fas fa-clipboard-user me-2"></i>अपनी क्लिनिकल चेक-इन शुरू करें',
-        'heroDesc': 'यह इनटेक डॉक्टर को आपकी मुलाकात के लिए तैयार करता है।',
-        'sectionDoctor': '👨‍⚕️ अपने डॉक्टर का चयन करें',
-        'sectionDemographics': '👤 व्यक्तिगत जानकारी',
-        'sectionVitals': '📊 महत्वपूर्ण संकेत',
-        'sectionMedical': '⚕️ चिकित्सीय जानकारी',
-        'sectionComplaint': '🏥 मुख्य शिकायत',
+    <!-- MAIN CONTENT -->
+    <main class="container my-5">
+      <div class="row justify-content-center">
+        <div class="col-lg-8 col-md-10">
+          <!-- HERO -->
+          <div class="hero-section">
+            <h2 id="heroTitle">
+              <i class="fas fa-clipboard-user me-2"></i>
+              Begin Your Clinical Check-In
+            </h2>
+            <p id="heroDesc">
+              This pre-visit intake will help your doctor prepare for your
+              appointment. Please answer honestly and thoroughly.
+            </p>
+          </div>
 
-        'lbl_name': 'पूरा नाम',
-        'lbl_age': 'उम्र <span class="req">*</span>',
-        'lbl_gender': 'लिंग',
-        'lbl_temp': 'तापमान (°C)',
-        'lbl_bp': 'रक्तचाप',
-        'lbl_allergies': 'एलर्जी <span class="req">*</span>',
-        'lbl_meds': 'वर्तमान दवाएं <span class="req">*</span>',
-        'lbl_symptoms': 'लक्षण बताएं <span class="req">*</span>',
-        'lbl_weight': 'वजन (किलोग्राम)',
-        'lbl_height': 'कद (सेंटीमीटर)',
+          {% if error %}
+          <div class="alert alert-danger mb-4">{{ error }}</div>
+          {% endif %}
 
-        'btnText': 'सारांश बनाएं'
-    },
+          <!-- LANGUAGE -->
+          <div class="d-flex justify-content-end mb-4">
+            <div style="max-width: 180px">
+              <label class="form-label small mb-2">Interface Language:</label>
+              <select
+                class="form-select form-select-sm"
+                id="languageSelect"
+                onchange="switchLanguage(this.value)"
+              >
+                <option value="English" selected>🇬🇧 English</option>
+                <option value="Hindi">🇮🇳 हिन्दी (Hindi)</option>
+              </select>
+            </div>
+          </div>
 
-    'English': {
-        'heroTitle': '<i class="fas fa-clipboard-user me-2"></i>Begin Your Clinical Check-In',
-        'heroDesc': 'This intake helps your doctor prepare for your visit.',
-        'sectionDoctor': '👨‍⚕️ Select Your Doctor',
-        'sectionDemographics': '👤 Personal Information',
-        'sectionVitals': '📊 Vital Signs',
-        'sectionMedical': '⚕️ Medical Information',
-        'sectionComplaint': '🏥 Chief Complaint',
+          <!-- FORM -->
+          <form
+            action="/patient/submit"
+            method="POST"
+            class="form-card"
+            novalidate
+          >
+            <input
+              type="hidden"
+              name="language"
+              id="hiddenLanguage"
+              value="English"
+            />
 
-        'lbl_name': 'Full Name',
-        'lbl_age': 'Age <span class="req">*</span>',
-        'lbl_gender': 'Gender',
-        'lbl_temp': 'Temperature (°C)',
-        'lbl_bp': 'Blood Pressure (optional)',
-        'lbl_allergies': 'Allergies <span class="req">*</span>',
-        'lbl_meds': 'Current Medications <span class="req">*</span>',
-        'lbl_symptoms': 'Describe Your Symptoms <span class="req">*</span>',
-        'lbl_weight': 'Weight (kg)',
-        'lbl_height': 'Height (cm)',
+            <div class="row g-3">
+              <!-- DOCTOR -->
+              <div class="col-12">
+                <div class="form-row-label" id="sectionDoctor">
+                  👨‍⚕️ Select Your Doctor
+                </div>
+              </div>
 
-        'btnText': 'Generate Clinical Summary'
-    }
-};
+              <div class="col-12">
+                <label class="form-label" id="lbl_doctor"
+                  >Which doctor are you visiting?
+                  <span class="req">*</span></label
+                >
+                <select
+                  id="selectDoctor"
+                  name="doctor_id"
+                  class="form-select"
+                  required
+                >
+                  <option value="">-- Select a Doctor --</option>
+                  {% for doctor in doctors %}
+                  <option value="{{ doctor.id }}">
+                    {{ doctor.name }} - {{ doctor.specialty }}
+                  </option>
+                  {% endfor %}
+                </select>
+              </div>
 
-function switchLanguage(lang) {
-    document.getElementById('hiddenLanguage').value = lang;
-    const data = TRANSLATIONS[lang];
+              <!-- DEMOGRAPHICS -->
+              <div class="col-12">
+                <div class="form-row-label" id="sectionDemographics">
+                  👤 Personal Information
+                </div>
+              </div>
 
-    const ids = [
-        'heroTitle','heroDesc','sectionDoctor','sectionDemographics','sectionVitals',
-        'sectionMedical','sectionComplaint','lbl_name','lbl_age','lbl_gender','lbl_temp',
-        'lbl_bp','lbl_allergies','lbl_meds','lbl_symptoms','lbl_weight','lbl_height','btnText'
-    ];
+              <div class="col-sm-6">
+                <label class="form-label" id="lbl_name">Full Name</label>
+                <input
+                  type="text"
+                  id="inputName"
+                  name="name"
+                  class="form-control"
+                  placeholder="Enter your full name"
+                  required
+                />
+              </div>
 
-    ids.forEach(id => {
-        const el = document.getElementById(id);
-        if (el && data[id]) el.innerHTML = data[id];
-    });
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_age"
+                  >Age <span class="req">*</span></label
+                >
+                <input
+                  type="number"
+                  id="inputAge"
+                  name="age"
+                  class="form-control"
+                  min="0"
+                  max="150"
+                  required
+                />
+              </div>
 
-    if (lang === 'Hindi') {
-        document.getElementById('inputName').placeholder = 'अपना पूरा नाम दर्ज करें';
-        document.getElementById('textSymptoms').placeholder = 'लक्षण विस्तार से लिखें...';
-    } else {
-        document.getElementById('inputName').placeholder = 'Enter your full name';
-        document.getElementById('textSymptoms').placeholder = 'Please describe your symptoms...';
-    }
-}
-</script>
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_gender">Gender</label>
+                <select id="selectGender" name="gender" class="form-select">
+                  <option>Female</option>
+                  <option>Male</option>
+                  <option>Other</option>
+                </select>
+              </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+              <!-- VITALS -->
+              <div class="col-12 mt-2">
+                <div class="form-row-label" id="sectionVitals">
+                  📊 Vital Signs
+                </div>
+              </div>
+
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_temp">Temperature (°C)</label>
+                <input
+                  type="number"
+                  id="inputTemp"
+                  name="temperature"
+                  class="form-control"
+                  min="30"
+                  max="45"
+                  step="0.1"
+                  placeholder="37.0"
+                />
+              </div>
+
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_bp"
+                  >Blood Pressure (optional)</label
+                >
+                <input
+                  type="text"
+                  id="inputBP"
+                  name="blood_pressure"
+                  class="form-control"
+                  placeholder="e.g. 120/80"
+                />
+              </div>
+
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_weight">Weight (kg)</label>
+                <input
+                  type="number"
+                  id="inputWeight"
+                  name="weight"
+                  class="form-control"
+                  min="1"
+                  max="500"
+                  step="0.1"
+                  placeholder="e.g. 70"
+                />
+              </div>
+
+              <div class="col-sm-3">
+                <label class="form-label" id="lbl_height">Height (cm)</label>
+                <input
+                  type="number"
+                  id="inputHeight"
+                  name="height"
+                  class="form-control"
+                  min="30"
+                  max="250"
+                  step="0.1"
+                  placeholder="e.g. 170"
+                />
+              </div>
+
+              <!-- MEDICAL -->
+              <div class="col-12 mt-2">
+                <div class="form-row-label" id="sectionMedical">
+                  ⚕️ Medical Information
+                </div>
+              </div>
+
+              <div class="col-md-6">
+                <label class="form-label" id="lbl_allergies"
+                  >Allergies <span class="req">*</span></label
+                >
+                <input
+                  type="text"
+                  id="inputAllergies"
+                  name="allergies"
+                  class="form-control"
+                  required
+                />
+              </div>
+
+              <div class="col-md-6">
+                <label class="form-label" id="lbl_meds"
+                  >Current Medications <span class="req">*</span></label
+                >
+                <input
+                  type="text"
+                  id="inputMeds"
+                  name="current_medications"
+                  class="form-control"
+                  required
+                />
+              </div>
+
+              <!-- SYMPTOMS -->
+              <div class="col-12 mt-2">
+                <div class="form-row-label" id="sectionComplaint">
+                  🏥 Chief Complaint
+                </div>
+              </div>
+
+              <div class="col-12">
+                <label class="form-label" id="lbl_symptoms"
+                  >Describe Your Symptoms <span class="req">*</span></label
+                >
+                <textarea
+                  id="textSymptoms"
+                  name="symptoms"
+                  class="form-control"
+                  rows="5"
+                  required
+                ></textarea>
+              </div>
+
+              <div class="col-12">
+                <div class="form-check">
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    value="1"
+                    name="confirm"
+                    required
+                  />
+                  <label class="form-check-label small-muted"
+                    >I confirm this data is accurate.</label
+                  >
+                </div>
+              </div>
+
+              <!-- SUBMIT -->
+              <div class="col-12 text-center mt-4">
+                <button type="submit" class="btn-medical w-100">
+                  <i class="fas fa-wand-magic-sparkles me-2"></i>
+                  <span id="btnText">Generate Clinical Summary</span>
+                </button>
+              </div>
+            </div>
+          </form>
+
+          {% if error %}
+          <div class="alert alert-danger mt-4">{{ error }}</div>
+          {% endif %}
+        </div>
+      </div>
+    </main>
+
+    <!-- TRANSLATION SCRIPT -->
+    <script>
+      const TRANSLATIONS = {
+        Hindi: {
+          heroTitle:
+            '<i class="fas fa-clipboard-user me-2"></i>अपनी क्लिनिकल चेक-इन शुरू करें',
+          heroDesc: "यह इनटेक डॉक्टर को आपकी मुलाकात के लिए तैयार करता है।",
+          sectionDoctor: "👨‍⚕️ अपने डॉक्टर का चयन करें",
+          sectionDemographics: "👤 व्यक्तिगत जानकारी",
+          sectionVitals: "📊 महत्वपूर्ण संकेत",
+          sectionMedical: "⚕️ चिकित्सीय जानकारी",
+          sectionComplaint: "🏥 मुख्य शिकायत",
+
+          lbl_name: "पूरा नाम",
+          lbl_age: 'उम्र <span class="req">*</span>',
+          lbl_gender: "लिंग",
+          lbl_temp: "तापमान (°C)",
+          lbl_bp: "रक्तचाप",
+          lbl_allergies: 'एलर्जी <span class="req">*</span>',
+          lbl_meds: 'वर्तमान दवाएं <span class="req">*</span>',
+          lbl_symptoms: 'लक्षण बताएं <span class="req">*</span>',
+          lbl_weight: "वजन (किलोग्राम)",
+          lbl_height: "कद (सेंटीमीटर)",
+
+          btnText: "सारांश बनाएं",
+        },
+
+        English: {
+          heroTitle:
+            '<i class="fas fa-clipboard-user me-2"></i>Begin Your Clinical Check-In',
+          heroDesc: "This intake helps your doctor prepare for your visit.",
+          sectionDoctor: "👨‍⚕️ Select Your Doctor",
+          sectionDemographics: "👤 Personal Information",
+          sectionVitals: "📊 Vital Signs",
+          sectionMedical: "⚕️ Medical Information",
+          sectionComplaint: "🏥 Chief Complaint",
+
+          lbl_name: "Full Name",
+          lbl_age: 'Age <span class="req">*</span>',
+          lbl_gender: "Gender",
+          lbl_temp: "Temperature (°C)",
+          lbl_bp: "Blood Pressure (optional)",
+          lbl_allergies: 'Allergies <span class="req">*</span>',
+          lbl_meds: 'Current Medications <span class="req">*</span>',
+          lbl_symptoms: 'Describe Your Symptoms <span class="req">*</span>',
+          lbl_weight: "Weight (kg)",
+          lbl_height: "Height (cm)",
+
+          btnText: "Generate Clinical Summary",
+        },
+      };
+
+      function switchLanguage(lang) {
+        document.getElementById("hiddenLanguage").value = lang;
+        const data = TRANSLATIONS[lang];
+
+        const ids = [
+          "heroTitle",
+          "heroDesc",
+          "sectionDoctor",
+          "sectionDemographics",
+          "sectionVitals",
+          "sectionMedical",
+          "sectionComplaint",
+          "lbl_name",
+          "lbl_age",
+          "lbl_gender",
+          "lbl_temp",
+          "lbl_bp",
+          "lbl_allergies",
+          "lbl_meds",
+          "lbl_symptoms",
+          "lbl_weight",
+          "lbl_height",
+          "btnText",
+        ];
+
+        ids.forEach((id) => {
+          const el = document.getElementById(id);
+          if (el && data[id]) el.innerHTML = data[id];
+        });
+
+        if (lang === "Hindi") {
+          document.getElementById("inputName").placeholder =
+            "अपना पूरा नाम दर्ज करें";
+          document.getElementById("textSymptoms").placeholder =
+            "लक्षण विस्तार से लिखें...";
+        } else {
+          document.getElementById("inputName").placeholder =
+            "Enter your full name";
+          document.getElementById("textSymptoms").placeholder =
+            "Please describe your symptoms...";
+        }
+      }
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
 </html>

--- a/templates/patient_result.html
+++ b/templates/patient_result.html
@@ -1,133 +1,163 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Your Health Summary | MediAssist</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
-</head>
-<body>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+  </head>
+  <body>
     <!-- NAVBAR -->
     <nav class="navbar">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-heartbeat"></i>
-                <span>MediAssist <small class="text-muted">Patient Summary</small></span>
-            </a>
-            <a href="/patient/logout" class="btn btn-outline-secondary btn-sm">
-                <i class="fas fa-home me-1"></i> Home
-            </a>
+      <div class="container">
+        <a class="navbar-brand" href="/">
+          <i class="fas fa-heartbeat"></i>
+          <span
+            >MediAssist <small class="text-muted">Patient Summary</small></span
+          >
+        </a>
+        <div class="d-flex gap-2">
+          <a href="/cases" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-folder-open me-1"></i>All Records
+          </a>
+          <a href="/patient/logout" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-home me-1"></i> Home
+          </a>
         </div>
+      </div>
     </nav>
 
     <div class="container my-5">
-        
-        <!-- Case ID Banner -->
-        <div class="alert alert-info text-center border-info shadow-sm">
-            <h4 class="fw-bold"><i class="fas fa-id-card me-2"></i> Case ID: <span class="text-primary">{{ case.raw_data.id }}</span></h4>
-            <p class="mb-0">Please show this ID to your doctor at reception to access your detailed clinical notes.</p>
-        </div>
+      <!-- Case ID Banner -->
+      <div class="alert alert-info text-center border-info shadow-sm">
+        <h4 class="fw-bold">
+          <i class="fas fa-id-card me-2"></i> Case ID:
+          <span class="text-primary">{{ case.raw_data.id }}</span>
+        </h4>
+        <p class="mb-0">
+          Please show this ID to your doctor at reception to access your
+          detailed clinical notes.
+        </p>
+      </div>
 
-        <div class="row justify-content-center">
-            <div class="col-lg-8">
-                
-                <!-- DIAGNOSIS CARD - SIMPLE -->
-                <div class="card shadow-sm border-0 mb-4 bg-primary-light">
-                    <div class="card-header bg-primary text-white">
-                        <h5 class="mb-0"><i class="fas fa-stethoscope me-2"></i>Your Most Probable Diagnosis</h5>
-                    </div>
-                    <div class="card-body">
-                        <p class="mb-0" style="font-size: 1.1rem; font-weight: 600; color: #003d99;">
-                            {{ case.ai_analysis.patient_view.primary_diagnosis }}
-                        </p>
-                    </div>
-                </div>
-
-                <!-- Patient Friendly View -->
-                <div class="card shadow-sm border-0 mb-4">
-                    <div class="card-header bg-primary text-white p-3">
-                        <h5 class="mb-0"><i class="fas fa-book-medical me-2"></i> What This Means For You</h5>
-                    </div>
-                    <div class="card-body p-4">
-                        <h6 class="text-primary mb-3">Understanding Your Condition:</h6>
-                        <p style="line-height: 1.6;">
-                            {{ case.ai_analysis.patient_view.summary | safe }}
-                        </p>
-                        
-                        <div class="bg-light p-3 rounded mb-4 border-left border-info">
-                            <h6 class="text-info mb-2">
-                                <i class="fas fa-microscope me-2"></i> 
-                                <strong>How Your Body Is Responding:</strong>
-                            </h6>
-                            <p class="mb-0" style="line-height: 1.6;">
-                                {{ case.ai_analysis.patient_view.pathophysiology | safe }}
-                            </p>
-                        </div>
-
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <div class="card bg-light border-left border-success">
-                                    <div class="card-body">
-                                        <h6 class="text-success mb-2">
-                                            <i class="fas fa-check-circle me-2"></i> 
-                                            <strong>What You Can Do:</strong>
-                                        </h6>
-                                        <ul class="list-unstyled small">
-                                            {% for step in case.ai_analysis.patient_view.care_plan %}
-                                            <li class="mb-2">
-                                                <i class="fas fa-arrow-right text-success me-2"></i>
-                                                {{ step | safe }}
-                                            </li>
-                                            {% endfor %}
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <div class="card bg-light border-left border-danger">
-                                    <div class="card-body">
-                                        <h6 class="text-danger mb-2">
-                                            <i class="fas fa-exclamation-triangle me-2"></i> 
-                                            <strong>Seek Help If:</strong>
-                                        </h6>
-                                        <ul class="list-unstyled small">
-                                            {% for flag in case.ai_analysis.patient_view.red_flags %}
-                                            <li class="mb-2">
-                                                <i class="fas fa-times-circle text-danger me-2"></i>
-                                                {{ flag | safe }}
-                                            </li>
-                                            {% endfor %}
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Safety Notice -->
-                        <div class="alert alert-warning mt-4 mb-0 small" role="alert">
-                            <i class="fas fa-info-circle me-2"></i>
-                            <strong>Important:</strong> This is an AI-generated educational summary. 
-                            Please consult your doctor for official diagnosis and treatment advice.
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Action Buttons -->
-                <div class="text-center mb-4">
-                    <a href="/patient/logout" class="btn btn-primary me-2">
-                        <i class="fas fa-home me-1"></i> Back to Home
-                    </a>
-                    <button onclick="window.print()" class="btn btn-outline-secondary">
-                        <i class="fas fa-print me-1"></i> Print Summary
-                    </button>
-                </div>
-
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <!-- DIAGNOSIS CARD - SIMPLE -->
+          <div class="card shadow-sm border-0 mb-4 bg-primary-light">
+            <div class="card-header bg-primary text-white">
+              <h5 class="mb-0">
+                <i class="fas fa-stethoscope me-2"></i>Your Most Probable
+                Diagnosis
+              </h5>
             </div>
+            <div class="card-body">
+              <p
+                class="mb-0"
+                style="font-size: 1.1rem; font-weight: 600; color: #003d99"
+              >
+                {{ case.ai_analysis.patient_view.primary_diagnosis }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Patient Friendly View -->
+          <div class="card shadow-sm border-0 mb-4">
+            <div class="card-header bg-primary text-white p-3">
+              <h5 class="mb-0">
+                <i class="fas fa-book-medical me-2"></i> What This Means For You
+              </h5>
+            </div>
+            <div class="card-body p-4">
+              <h6 class="text-primary mb-3">Understanding Your Condition:</h6>
+              <p style="line-height: 1.6">
+                {{ case.ai_analysis.patient_view.summary | safe }}
+              </p>
+
+              <div class="bg-light p-3 rounded mb-4 border-left border-info">
+                <h6 class="text-info mb-2">
+                  <i class="fas fa-microscope me-2"></i>
+                  <strong>How Your Body Is Responding:</strong>
+                </h6>
+                <p class="mb-0" style="line-height: 1.6">
+                  {{ case.ai_analysis.patient_view.pathophysiology | safe }}
+                </p>
+              </div>
+
+              <div class="row">
+                <div class="col-md-6 mb-3">
+                  <div class="card bg-light border-left border-success">
+                    <div class="card-body">
+                      <h6 class="text-success mb-2">
+                        <i class="fas fa-check-circle me-2"></i>
+                        <strong>What You Can Do:</strong>
+                      </h6>
+                      <ul class="list-unstyled small">
+                        {% for step in case.ai_analysis.patient_view.care_plan
+                        %}
+                        <li class="mb-2">
+                          <i class="fas fa-arrow-right text-success me-2"></i>
+                          {{ step | safe }}
+                        </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <div class="card bg-light border-left border-danger">
+                    <div class="card-body">
+                      <h6 class="text-danger mb-2">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        <strong>Seek Help If:</strong>
+                      </h6>
+                      <ul class="list-unstyled small">
+                        {% for flag in case.ai_analysis.patient_view.red_flags
+                        %}
+                        <li class="mb-2">
+                          <i class="fas fa-times-circle text-danger me-2"></i>
+                          {{ flag | safe }}
+                        </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Safety Notice -->
+              <div class="alert alert-warning mt-4 mb-0 small" role="alert">
+                <i class="fas fa-info-circle me-2"></i>
+                <strong>Important:</strong> This is an AI-generated educational
+                summary. Please consult your doctor for official diagnosis and
+                treatment advice.
+              </div>
+            </div>
+          </div>
+
+          <!-- Action Buttons -->
+          <div class="text-center mb-4">
+            <a href="/patient/logout" class="btn btn-primary me-2">
+              <i class="fas fa-home me-1"></i> Back to Home
+            </a>
+            <button onclick="window.print()" class="btn btn-outline-secondary">
+              <i class="fas fa-print me-1"></i> Print Summary
+            </button>
+          </div>
         </div>
+      </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
This pull request resolves the issue #8 

It introduces a new `cases.html` template for listing cases and makes several improvements to the `doctor_dashboard.html` and `intake.html` templates. The main focus is on enhancing navigation, code readability, and the user interface for both doctors and patients.

**Key changes include:**

### New Feature: Cases Listing Page

* Added a new `cases.html` template that displays all cases in a styled table, with role-based views, status badges, and empty state messaging. This page supports both doctors (assigned cases) and patients (their health records), and includes navigation and summary counts.

### Navigation and Accessibility Improvements

* Added "All Cases"/"All Records" navigation buttons to both the doctor dashboard (`doctor_dashboard.html`) and the patient intake form (`intake.html`), making it easier for users to access their case history from multiple locations.
* Improved navbar and button alignment and consistency across templates for a more cohesive user experience.

### Reference Screenshots

**Patient All Records**
![patient all reacords](https://github.com/user-attachments/assets/7bc5b2e6-c688-4824-9788-a061cbca612f)

**Doctor All Cases**
![doctor all cases](https://github.com/user-attachments/assets/efdf5a6d-7fae-4f07-99cc-6a7c690e84c5)

