### PR TITLE
Add dark mode toggle across pages

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -74,6 +74,71 @@
   --transition-fast: 150ms ease-in-out;
   --transition-base: 300ms ease-in-out;
   --transition-slow: 500ms ease-in-out;
+
+  /* Background Colors */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --bg-tertiary: #f3f4f6;
+
+  /* Text Colors */
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-muted: #6b7280;
+
+  /* Border Colors */
+  --border-color: #e5e7eb;
+  --border-color-light: #f3f4f6;
+}
+
+/* ========================================
+   DARK MODE VARIABLES
+   ======================================== */
+
+[data-theme="dark"] {
+  /* Dark Mode Color Palette */
+  --color-primary: #3b82f6; /* Brighter blue for dark mode */
+  --color-primary-light: #1e3a5f; /* Darker for backgrounds */
+  --color-primary-dark: #60a5fa; /* Lighter for accents */
+  --color-secondary: #22d3ee; /* Cyan for dark mode */
+  --color-success: #34d399; /* Slightly brighter green */
+  --color-warning: #fbbf24; /* Brighter amber */
+  --color-danger: #f87171; /* Softer red */
+  --color-info: #38bdf8; /* Sky blue */
+
+  /* Dark Neutral Palette */
+  --color-gray-50: #18181b;
+  --color-gray-100: #27272a;
+  --color-gray-200: #3f3f46;
+  --color-gray-300: #52525b;
+  --color-gray-400: #71717a;
+  --color-gray-500: #a1a1aa;
+  --color-gray-600: #d4d4d8;
+  --color-gray-700: #e4e4e7;
+  --color-gray-800: #f4f4f5;
+  --color-gray-900: #fafafa;
+
+  /* Dark Mode Backgrounds */
+  --bg-primary: #0f172a;
+  --bg-secondary: #1e293b;
+  --bg-tertiary: #334155;
+
+  /* Dark Mode Text */
+  --text-primary: #f1f5f9;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+
+  /* Dark Mode Borders */
+  --border-color: #334155;
+  --border-color-light: #1e293b;
+
+  /* Dark Mode Shadows - softer for dark backgrounds */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4),
+    0 2px 4px -1px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4),
+    0 4px 6px -2px rgba(0, 0, 0, 0.3);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.5),
+    0 10px 10px -5px rgba(0, 0, 0, 0.4);
 }
 
 /* ========================================
@@ -96,9 +161,11 @@ body {
   font-family: var(--font-family-base);
   font-size: var(--font-size-base);
   line-height: 1.6;
-  color: var(--color-gray-700);
-  background-color: var(--color-gray-50);
+  color: var(--text-secondary);
+  background-color: var(--bg-secondary);
   min-height: 100vh;
+  transition: background-color var(--transition-base),
+    color var(--transition-base);
 }
 
 /* ========================================
@@ -980,4 +1047,323 @@ textarea.form-control {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
+}
+
+/* ========================================
+   SETTINGS POPUP & TOGGLES
+   ======================================== */
+
+/* Floating Settings Button */
+.settings-fab {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 1050;
+  width: 60px;
+  height: 60px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-secondary)
+  );
+  border: none;
+  box-shadow: var(--shadow-xl);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-base);
+  color: var(--color-white);
+  font-size: 1.5rem;
+}
+
+.settings-fab:hover {
+  transform: scale(1.1) rotate(90deg);
+  box-shadow: 0 8px 24px rgba(0, 82, 204, 0.4);
+}
+
+.settings-fab:active {
+  transform: scale(0.95);
+}
+
+.settings-fab.active {
+  transform: rotate(90deg);
+}
+
+/* Settings Popup Panel */
+.settings-popup {
+  position: fixed;
+  bottom: 100px;
+  right: 30px;
+  z-index: 1049;
+  width: 280px;
+  background: var(--bg-primary);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px) scale(0.95);
+  transition: all var(--transition-base);
+}
+
+.settings-popup.show {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.settings-popup-header {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-section {
+  margin-bottom: 1.25rem;
+}
+
+.settings-section:last-child {
+  margin-bottom: 0;
+}
+
+.settings-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Theme Toggle in Popup */
+.theme-switch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.theme-switch:hover {
+  background: var(--bg-secondary);
+  transform: translateX(4px);
+}
+
+.theme-switch-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.theme-switch-icon {
+  font-size: 1.25rem;
+  width: 28px;
+  text-align: center;
+}
+
+.theme-switch-toggle {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  background: var(--color-gray-400);
+  border-radius: var(--radius-full);
+  transition: background var(--transition-base);
+}
+
+.theme-switch-toggle::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background: var(--color-white);
+  border-radius: var(--radius-full);
+  transition: transform var(--transition-base);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .theme-switch-toggle {
+  background: var(--color-primary);
+}
+
+[data-theme="dark"] .theme-switch-toggle::after {
+  transform: translateX(22px);
+}
+
+/* Language Toggle in Popup */
+.language-section {
+  padding: 0.75rem;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+}
+
+.language-section .language-toggle {
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.language-section .lang-btn {
+  flex: 1;
+  text-align: center;
+  padding: 0.6rem 0.5rem;
+  font-size: 0.9rem;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .settings-fab {
+    width: 56px;
+    height: 56px;
+    bottom: 20px;
+    right: 20px;
+    font-size: 1.35rem;
+  }
+
+  .settings-popup {
+    bottom: 88px;
+    right: 20px;
+    width: calc(100vw - 40px);
+    max-width: 320px;
+  }
+}
+
+/* ========================================
+   DARK MODE COMPONENT OVERRIDES
+   ======================================== */
+
+[data-theme="dark"] .card,
+[data-theme="dark"] .form-card,
+[data-theme="dark"] .result-box {
+  background-color: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .navbar {
+  background-color: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .form-select,
+[data-theme="dark"] textarea {
+  background-color: var(--bg-tertiary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .form-control:focus,
+[data-theme="dark"] .form-select:focus,
+[data-theme="dark"] textarea:focus {
+  background-color: var(--bg-secondary);
+  border-color: var(--color-primary);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .form-control::placeholder,
+[data-theme="dark"] textarea::placeholder {
+  color: var(--text-muted);
+}
+
+[data-theme="dark"] .alert {
+  background-color: var(--bg-tertiary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .table {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .table thead {
+  background-color: var(--bg-tertiary);
+}
+
+[data-theme="dark"] .table tbody tr {
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] .table tbody tr:hover {
+  background-color: var(--bg-tertiary);
+}
+
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6 {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .text-muted,
+[data-theme="dark"] .small-muted {
+  color: var(--text-muted) !important;
+}
+
+[data-theme="dark"] .btn-medical {
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-secondary)
+  );
+  border: none;
+  color: var(--color-white);
+}
+
+[data-theme="dark"] .btn-medical:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+[data-theme="dark"] .btn-outline-secondary {
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .btn-outline-secondary:hover {
+  background-color: var(--bg-tertiary);
+  border-color: var(--color-primary);
+}
+
+[data-theme="dark"] hr {
+  border-color: var(--border-color);
+  opacity: 0.3;
+}
+
+/* Dark mode for inline landing page styles */
+[data-theme="dark"] .role-card {
+  background-color: var(--bg-primary) !important;
+  border: 1px solid var(--border-color) !important;
+}
+
+[data-theme="dark"] .role-card:hover {
+  border-color: var(--color-primary) !important;
+}
+
+/* Ensure readable contrast for badges and labels */
+[data-theme="dark"] .badge {
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+/* Optimize for long reading sessions - reduce brightness */
+[data-theme="dark"] {
+  filter: brightness(0.95);
 }

--- a/templates/_settings_popup.html
+++ b/templates/_settings_popup.html
@@ -1,0 +1,41 @@
+<!-- Settings Floating Button & Popup -->
+<button class="settings-fab" aria-label="Settings" title="Settings">
+  <i class="fas fa-cog"></i>
+</button>
+
+<div class="settings-popup">
+  <div class="settings-popup-header">
+    <i class="fas fa-sliders-h"></i>
+    Settings
+  </div>
+
+  <!-- Theme Toggle Section -->
+  <div class="settings-section">
+    <div class="settings-label"><i class="fas fa-palette"></i> Appearance</div>
+    <div
+      class="theme-switch"
+      role="button"
+      tabindex="0"
+      aria-label="Toggle dark mode"
+    >
+      <div class="theme-switch-label">
+        <span class="theme-switch-icon">
+          <i class="fas fa-sun" data-theme-icon="light"></i>
+          <i
+            class="fas fa-moon"
+            data-theme-icon="dark"
+            style="display: none"
+          ></i>
+        </span>
+        <span id="theme-label">Dark Mode</span>
+      </div>
+      <div class="theme-switch-toggle"></div>
+    </div>
+  </div>
+
+  <!-- Language Toggle Section -->
+  <div class="settings-section">
+    <div class="settings-label"><i class="fas fa-language"></i> Language</div>
+    <div class="language-section">{% include '_language_toggle.html' %}</div>
+  </div>
+</div>

--- a/templates/cases.html
+++ b/templates/cases.html
@@ -12,9 +12,17 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
       body {
         background: #f8fafc;
+        transition: background 0.3s ease;
+      }
+      [data-theme="dark"] body {
+        background: #0f172a;
       }
       .cases-header {
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -114,6 +122,8 @@
     </style>
   </head>
   <body>
+    {% include '_settings_popup.html' %}
+
     <!-- NAVBAR -->
     <nav class="navbar navbar-dark bg-dark">
       <div class="container-fluid">
@@ -121,7 +131,7 @@
           <i class="fas fa-hospital-user me-2"></i>{{ t.common.app_name }}
         </a>
         <div class="d-flex align-items-center gap-3">
-          {% include '_language_toggle.html' %} {% if role == 'doctor' %}
+          {% if role == 'doctor' %}
           <a href="/doctor/dashboard" class="btn btn-outline-light btn-sm">
             <i class="fas fa-home me-1"></i>Dashboard
           </a>
@@ -259,5 +269,6 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/doctor_dashboard.html
+++ b/templates/doctor_dashboard.html
@@ -12,9 +12,17 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
       body {
         background: #f8fafc;
+        transition: background 0.3s ease;
+      }
+      [data-theme="dark"] body {
+        background: #0f172a;
       }
       .dashboard-header {
         background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
@@ -66,6 +74,8 @@
     </style>
   </head>
   <body>
+    {% include '_settings_popup.html' %}
+
     <!-- NAVBAR -->
     <nav class="navbar navbar-dark bg-dark">
       <div class="container-fluid">
@@ -74,7 +84,6 @@
           t.doctor_dashboard.provider_portal }}
         </a>
         <div class="d-flex align-items-center gap-3">
-          {% include '_language_toggle.html' %}
           <a href="/cases" class="btn btn-outline-light btn-sm">
             <i class="fas fa-folder-open me-1"></i>{{ t.common.all_cases }}
           </a>
@@ -188,5 +197,6 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/doctor_login.html
+++ b/templates/doctor_login.html
@@ -12,12 +12,21 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
       body {
         background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
         display: flex;
         align-items: center;
         justify-content: center;
+        transition: background 0.3s ease;
+      }
+      [data-theme="dark"] body {
+        background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+      }
         min-height: 100vh;
         font-family: "Inter", sans-serif;
       }
@@ -94,9 +103,8 @@
     </style>
   </head>
   <body>
-    <div style="position: fixed; top: 20px; right: 20px; z-index: 1000">
-      {% include '_language_toggle.html' %}
-    </div>
+    {% include '_settings_popup.html' %}
+
     <div class="login-card">
       <div class="login-header">
         <h2><i class="fas fa-user-md me-2"></i>{{ t.doctor_login.title }}</h2>
@@ -152,5 +160,7 @@
         <a href="/"><i class="fas fa-arrow-left me-1"></i>Back to Home</a>
       </div>
     </div>
+
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/doctor_view.html
+++ b/templates/doctor_view.html
@@ -1,394 +1,449 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
+  <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ t.doctor_view.title }} | {{ case.raw_data.id }}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
-        body {
-            background: #f8fafc;
-            padding-bottom: 50px;
-        }
+      body {
+        background: #f8fafc;
+        padding-bottom: 50px;
+      }
 
-        .soap-section {
-            margin-bottom: 2.5rem;
-        }
+      .soap-section {
+        margin-bottom: 2.5rem;
+      }
 
-        .soap-label {
-            font-size: 1.1rem;
-            font-weight: 700;
-            color: #0052cc;
-            margin-bottom: 1.25rem;
-            display: block;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            border-bottom: 2px solid #0052cc;
-            padding-bottom: 0.75rem;
-        }
+      .soap-label {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: #0052cc;
+        margin-bottom: 1.25rem;
+        display: block;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        border-bottom: 2px solid #0052cc;
+        padding-bottom: 0.75rem;
+      }
 
-        .soap-list {
-            list-style: none;
-            padding-left: 0;
-            margin-bottom: 0;
-        }
+      .soap-list {
+        list-style: none;
+        padding-left: 0;
+        margin-bottom: 0;
+      }
 
-        .soap-list li {
-            background: #f3f4f6;
-            border-left: 4px solid #0052cc;
-            padding: 1.25rem;
-            margin-bottom: 1rem;
-            border-radius: 0 6px 6px 0;
-            line-height: 1.8;
-            color: #374151;
-            counter-increment: step-counter;
-        }
+      .soap-list li {
+        background: #f3f4f6;
+        border-left: 4px solid #0052cc;
+        padding: 1.25rem;
+        margin-bottom: 1rem;
+        border-radius: 0 6px 6px 0;
+        line-height: 1.8;
+        color: #374151;
+        counter-increment: step-counter;
+      }
 
-        .soap-list li::before {
-            content: counter(step-counter);
-            display: inline-block;
-            background: #0052cc;
-            color: white;
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
-            text-align: center;
-            line-height: 28px;
-            font-weight: 700;
-            margin-right: 0.75rem;
-            font-size: 0.85rem;
-            flex-shrink: 0;
-        }
+      .soap-list li::before {
+        content: counter(step-counter);
+        display: inline-block;
+        background: #0052cc;
+        color: white;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        text-align: center;
+        line-height: 28px;
+        font-weight: 700;
+        margin-right: 0.75rem;
+        font-size: 0.85rem;
+        flex-shrink: 0;
+      }
 
-        .soap-list {
-            counter-reset: step-counter;
-        }
+      .soap-list {
+        counter-reset: step-counter;
+      }
 
-        .paper-card {
-            background: white;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-            border: 1px solid #e2e8f0;
-            border-radius: 12px;
-        }
+      .paper-card {
+        background: white;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+      }
 
-        .card-header {
-            background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-            border-bottom: 2px solid #d1d5db;
-        }
+      .card-header {
+        background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+        border-bottom: 2px solid #d1d5db;
+      }
 
-        .diagnosis-highlight {
-            background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
-            border-left: 5px solid #0284c7;
-            padding: 1.5rem;
-            margin-bottom: 2rem;
-            border-radius: 8px;
-            font-size: 1.05rem;
-            line-height: 1.8;
-        }
+      .diagnosis-highlight {
+        background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
+        border-left: 5px solid #0284c7;
+        padding: 1.5rem;
+        margin-bottom: 2rem;
+        border-radius: 8px;
+        font-size: 1.05rem;
+        line-height: 1.8;
+      }
 
-        .vitals-box {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 8px;
-            padding: 1.25rem;
-            margin-bottom: 1.5rem;
-        }
+      .vitals-box {
+        background: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        padding: 1.25rem;
+        margin-bottom: 1.5rem;
+      }
 
-        .vitals-box h6 {
-            font-weight: 700;
-            color: #1f2937;
-            margin-bottom: 0.75rem;
-            font-size: 0.95rem;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
+      .vitals-box h6 {
+        font-weight: 700;
+        color: #1f2937;
+        margin-bottom: 0.75rem;
+        font-size: 0.95rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
 
-        .vitals-box ul {
-            list-style: none;
-            padding-left: 0;
-            margin-bottom: 0;
-        }
+      .vitals-box ul {
+        list-style: none;
+        padding-left: 0;
+        margin-bottom: 0;
+      }
 
-        .vitals-box li {
-            padding: 0.5rem 0;
-            border-bottom: 1px solid #e5e7eb;
-            font-size: 0.95rem;
-        }
+      .vitals-box li {
+        padding: 0.5rem 0;
+        border-bottom: 1px solid #e5e7eb;
+        font-size: 0.95rem;
+      }
 
-        .vitals-box li:last-child {
-            border-bottom: none;
-        }
+      .vitals-box li:last-child {
+        border-bottom: none;
+      }
 
-        strong {
-            color: #1f2937;
-            font-weight: 700;
-        }
+      strong {
+        color: #1f2937;
+        font-weight: 700;
+      }
 
-        .alert-danger {
-            background: #fee2e2;
-            border: 1px solid #fecaca;
-            border-left: 5px solid #dc2626;
-        }
+      .alert-danger {
+        background: #fee2e2;
+        border: 1px solid #fecaca;
+        border-left: 5px solid #dc2626;
+      }
 
-        .alert-danger h5 {
-            color: #991b1b;
-        }
+      .alert-danger h5 {
+        color: #991b1b;
+      }
     </style>
-</head>
+  </head>
 
-<body>
+  <body>
+    {% include '_settings_popup.html' %}
+
     <!-- NAVBAR -->
     <nav class="navbar">
-        <div class="container">
-            <a class="navbar-brand" href="/doctor/dashboard">
-                <i class="fas fa-stethoscope"></i>
-                <span>{{ t.common.app_name }}
-                    <small class="text-muted">{{ t.intake.provider_portal }}</small></span>
-            </a>
-            <div class="d-flex gap-2 align-items-center">
-                {% include '_language_toggle.html' %}
-                <a href="/doctor/logout" class="btn btn-outline-danger btn-sm">
-                    <i class="fas fa-sign-out-alt me-1"></i> {{ t.common.logout }}
-                </a>
-            </div>
+      <div class="container">
+        <a class="navbar-brand" href="/doctor/dashboard">
+          <i class="fas fa-stethoscope"></i>
+          <span
+            >{{ t.common.app_name }}
+            <small class="text-muted"
+              >{{ t.intake.provider_portal }}</small
+            ></span
+          >
+        </a>
+        <div class="d-flex gap-2 align-items-center">
+          <a href="/doctor/logout" class="btn btn-outline-danger btn-sm">
+            <i class="fas fa-sign-out-alt me-1"></i> {{ t.common.logout }}
+          </a>
         </div>
+      </div>
     </nav>
 
     <div class="container my-5">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <div>
-                <a href="/doctor/dashboard" class="text-decoration-none text-muted mb-2 d-inline-block">
-                    <i class="fas fa-arrow-left me-1"></i> {{
-                    t.doctor_view.back_to_dashboard }}
-                </a>
-                <h3 class="mt-2">
-                    <span class="text-muted small">{{ t.doctor_view.case_id }}:</span>
-                    <code class="text-primary fw-bold">{{ case.raw_data.id }}</code>
-                </h3>
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+          <a
+            href="/doctor/dashboard"
+            class="text-decoration-none text-muted mb-2 d-inline-block"
+          >
+            <i class="fas fa-arrow-left me-1"></i> {{
+            t.doctor_view.back_to_dashboard }}
+          </a>
+          <h3 class="mt-2">
+            <span class="text-muted small">{{ t.doctor_view.case_id }}:</span>
+            <code class="text-primary fw-bold">{{ case.raw_data.id }}</code>
+          </h3>
+        </div>
+        <button
+          onclick="window.print()"
+          class="btn btn-primary"
+          title="Print to EMR"
+        >
+          <i class="fas fa-print me-2"></i>Print to EMR
+        </button>
+      </div>
+
+      <div class="card paper-card">
+        <!-- HEADER WITH PATIENT INFO -->
+        <div class="card-header p-4">
+          <div class="row align-items-center">
+            <div class="col-md-3">
+              <small class="text-muted text-uppercase">Patient Name</small
+              ><br />
+              <strong class="fs-5">{{ case.raw_data.name }}</strong>
             </div>
-            <button onclick="window.print()" class="btn btn-primary" title="Print to EMR">
-                <i class="fas fa-print me-2"></i>Print to EMR
-            </button>
+            <div class="col-md-3">
+              <small class="text-muted text-uppercase">Demographics</small
+              ><br />
+              <strong
+                >{{ case.raw_data.age }} years old / {{ case.raw_data.gender
+                }}</strong
+              >
+            </div>
+            <div class="col-md-3">
+              <small class="text-muted text-uppercase">Risk Level</small><br />
+              {% if case.ai_analysis.doctor_view.urgency_level == 'High' %}
+              <span class="badge bg-danger fs-6">High Urgency</span>
+              {% elif case.ai_analysis.doctor_view.urgency_level == 'Medium' %}
+              <span class="badge bg-warning text-dark fs-6"
+                >Medium Urgency</span
+              >
+              {% else %}
+              <span class="badge bg-success fs-6">Low Urgency</span>
+              {% endif %} {% if case.ai_analysis.doctor_view.follow_up_required
+              %}
+              <span class="badge bg-info text-dark ms-2">Follow-up Req.</span>
+              {% endif %}
+            </div>
+            <div class="col-md-3">
+              <small class="text-muted text-uppercase">⚠️ Allergies</small
+              ><br />
+              <span class="badge bg-danger fs-6"
+                >{{ case.raw_data.allergies }}</span
+              >
+            </div>
+          </div>
         </div>
 
-        <div class="card paper-card">
-            <!-- HEADER WITH PATIENT INFO -->
-            <div class="card-header p-4">
-                <div class="row align-items-center">
-                    <div class="col-md-3">
-                        <small class="text-muted text-uppercase">Patient Name</small><br />
-                        <strong class="fs-5">{{ case.raw_data.name }}</strong>
-                    </div>
-                    <div class="col-md-3">
-                        <small class="text-muted text-uppercase">Demographics</small><br />
-                        <strong>{{ case.raw_data.age }} years old / {{ case.raw_data.gender
-                            }}</strong>
-                    </div>
-                    <div class="col-md-3">
-                        <small class="text-muted text-uppercase">Risk Level</small><br>
-                        {% if case.ai_analysis.doctor_view.urgency_level == 'High' %}
-                        <span class="badge bg-danger fs-6">High Urgency</span>
-                        {% elif case.ai_analysis.doctor_view.urgency_level == 'Medium' %}
-                        <span class="badge bg-warning text-dark fs-6">Medium Urgency</span>
-                        {% else %}
-                        <span class="badge bg-success fs-6">Low Urgency</span>
-                        {% endif %}
+        <!-- BODY -->
+        <div class="card-body p-5">
+          <!-- SAFETY ALERT (if applicable) -->
+          {% if not case.ai_analysis.safety.is_safe %}
+          <div class="alert alert-danger mb-4" role="alert">
+            <h5 class="alert-heading">
+              <i class="fas fa-exclamation-triangle me-2"></i>
+              <strong>Note:</strong>
+            </h5>
+            <ul class="mb-0 ps-3">
+              {% for warn in case.ai_analysis.safety.warnings %}
+              <li class="mb-2"><strong>{{ warn | safe }}</strong></li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
 
-                        {% if case.ai_analysis.doctor_view.follow_up_required %}
-                        <span class="badge bg-info text-dark ms-2">Follow-up Req.</span>
-                        {% endif %}
-                    </div>
-                    <div class="col-md-3">
-                        <small class="text-muted text-uppercase">⚠️ Allergies</small><br />
-                        <span class="badge bg-danger fs-6">{{ case.raw_data.allergies }}</span>
-                    </div>
-                </div>
+          <!-- PRIMARY DIAGNOSIS HIGHLIGHT -->
+          <div class="diagnosis-highlight">
+            <strong
+              ><i class="fas fa-check-circle me-2 text-info"></i>{{
+              t.doctor_view.diagnosis_title }}</strong
+            ><br />
+            <span style="font-size: 1.2rem; margin-top: 0.5rem; display: block">
+              {{ case.ai_analysis.patient_view.primary_diagnosis | safe }}
+            </span>
+          </div>
+
+          <!-- VITALS & MEDICATIONS SUMMARY -->
+          <div class="row mb-4">
+            <div class="col-md-6">
+              <div class="vitals-box">
+                <h6>
+                  <i class="fas fa-heartbeat me-2 text-danger"></i>{{
+                  t.doctor_view.vitals }}
+                </h6>
+                <ul>
+                  <li>
+                    <strong>{{ t.doctor_view.temp }}:</strong>
+                    <span class="float-end">{{ case.raw_data.temp }}°C</span>
+                  </li>
+                  <li>
+                    <strong>{{ t.doctor_view.bp }}:</strong>
+                    <span class="float-end"
+                      >{{ case.raw_data.bp if case.raw_data.bp else 'Not
+                      recorded' }}</span
+                    >
+                  </li>
+                  <li>
+                    <strong>{{ t.doctor_view.weight }}:</strong>
+                    <span class="float-end"
+                      >{{ case.raw_data.weight if case.raw_data.weight else
+                      'N/A' }} kg</span
+                    >
+                  </li>
+                  <li>
+                    <strong>{{ t.doctor_view.height }}:</strong>
+                    <span class="float-end"
+                      >{{ case.raw_data.height if case.raw_data.height else
+                      'N/A' }} cm</span
+                    >
+                  </li>
+                </ul>
+              </div>
             </div>
-
-            <!-- BODY -->
-            <div class="card-body p-5">
-                <!-- SAFETY ALERT (if applicable) -->
-                {% if not case.ai_analysis.safety.is_safe %}
-                <div class="alert alert-danger mb-4" role="alert">
-                    <h5 class="alert-heading">
-                        <i class="fas fa-exclamation-triangle me-2"></i>
-                        <strong>Note:</strong>
-                    </h5>
-                    <ul class="mb-0 ps-3">
-                        {% for warn in case.ai_analysis.safety.warnings %}
-                        <li class="mb-2"><strong>{{ warn | safe }}</strong></li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                {% endif %}
-
-                <!-- PRIMARY DIAGNOSIS HIGHLIGHT -->
-                <div class="diagnosis-highlight">
-                    <strong><i class="fas fa-check-circle me-2 text-info"></i>{{ t.doctor_view.diagnosis_title
-                        }}</strong><br />
-                    <span style="font-size: 1.2rem; margin-top: 0.5rem; display: block">
-                        {{ case.ai_analysis.patient_view.primary_diagnosis | safe }}
-                    </span>
-                </div>
-
-                <!-- VITALS & MEDICATIONS SUMMARY -->
-                <div class="row mb-4">
-                    <div class="col-md-6">
-                        <div class="vitals-box">
-                            <h6>
-                                <i class="fas fa-heartbeat me-2 text-danger"></i>{{
-                                t.doctor_view.vitals }}
-                            </h6>
-                            <ul>
-                                <li>
-                                    <strong>{{ t.doctor_view.temp }}:</strong>
-                                    <span class="float-end">{{ case.raw_data.temp }}°C</span>
-                                </li>
-                                <li>
-                                    <strong>{{ t.doctor_view.bp }}:</strong>
-                                    <span class="float-end">{{ case.raw_data.bp if case.raw_data.bp else 'Not
-                                        recorded' }}</span>
-                                </li>
-                                <li>
-                                    <strong>{{ t.doctor_view.weight }}:</strong>
-                                    <span class="float-end">{{ case.raw_data.weight if case.raw_data.weight else
-                                        'N/A' }} kg</span>
-                                </li>
-                                <li>
-                                    <strong>{{ t.doctor_view.height }}:</strong>
-                                    <span class="float-end">{{ case.raw_data.height if case.raw_data.height else
-                                        'N/A' }} cm</span>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="vitals-box">
-                            <h6>
-                                <i class="fas fa-prescription-bottle me-2 text-primary"></i>{{ t.doctor_view.meds }}
-                            </h6>
-                            <p class="mb-0">{{ case.raw_data.current_meds }}</p>
-                            <hr class="my-2" />
-                            <h6 class="mt-3">
-                                <i class="fas fa-history me-2 text-warning"></i>{{
-                                t.doctor_view.history }}
-                            </h6>
-                            <p class="mb-0">{{ case.raw_data.history }}</p>
-                        </div>
-                    </div>
-                </div>
-
-                <hr class="my-5" />
-
-                <!-- SOAP NOTE SECTIONS AS LISTS -->
-
-                <!-- S - SUBJECTIVE -->
-                <div class="soap-section">
-                    <span class="soap-label">
-                        <i class="fas fa-comment-medical me-2"></i>{{ t.doctor_view.soap_s
-                        }}
-                    </span>
-                    <ul class="soap-list">
-                        {% for item in case.ai_analysis.doctor_view.subjective_list %}
-                        <li>{{ item | safe }}</li>
-                        {% endfor %}
-                    </ul>
-                    <div class="vitals-box mt-3">
-                        <small><strong>{{ t.doctor_view.duration }}:</strong> {{
-                            case.raw_data.duration }}</small><br />
-                        <small><strong>{{ t.doctor_view.severity }}:</strong> {{
-                            case.raw_data.severity }}</small><br />
-                        <small><strong>{{ t.doctor_view.notes }}:</strong> {{
-                            case.raw_data.notes if case.raw_data.notes else 'None' }}</small>
-                    </div>
-                </div>
-
-                <!-- O - OBJECTIVE -->
-                <div class="soap-section">
-                    <span class="soap-label">
-                        <i class="fas fa-stethoscope me-2"></i>{{ t.doctor_view.soap_o }}
-                    </span>
-                    <ul class="soap-list">
-                        {% for item in case.ai_analysis.doctor_view.objective_list %}
-                        <li>{{ item | safe }}</li>
-                        {% endfor %}
-                    </ul>
-                    <div class="vitals-box mt-3">
-                        <small><strong>{{ t.doctor_view.symptoms }}:</strong> {{
-                            case.raw_data.symptoms }}</small>
-                    </div>
-                </div>
-
-                <!-- A - ASSESSMENT -->
-                <div class="soap-section">
-                    <span class="soap-label">
-                        <i class="fas fa-brain me-2"></i>{{ t.doctor_view.soap_a }}
-                    </span>
-
-                    <!-- Confidence Scores -->
-                    {% if case.ai_analysis.doctor_view.possible_conditions %}
-                    <div class="mb-4">
-                        <h6 class="text-muted mb-3">Diagnostic Confidence:</h6>
-                        {% for condition in case.ai_analysis.doctor_view.possible_conditions %}
-                        <div class="mb-3">
-                            <div class="d-flex justify-content-between mb-1">
-                                <span>{{ condition.name }}</span>
-                                <span class="fw-bold">{{ (condition.confidence * 100) | round | int }}%</span>
-                            </div>
-                            <div class="progress" style="height: 10px;">
-                                <div class="progress-bar {% if condition.confidence > 0.7 %}bg-success{% elif condition.confidence > 0.4 %}bg-warning{% else %}bg-danger{% endif %}"
-                                    role="progressbar" style="width: {{ condition.confidence * 100 }}%">
-                                </div>
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                    <hr>
-                    {% endif %}
-
-                    <ul class="soap-list">
-                        {% for item in case.ai_analysis.doctor_view.assessment_list %}
-                        <li>{{ item | safe }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-
-                <!-- P - PLAN -->
-                <div class="soap-section">
-                    <span class="soap-label">
-                        <i class="fas fa-clipboard-list me-2"></i>{{ t.doctor_view.soap_p
-                        }}
-                    </span>
-                    <ul class="soap-list">
-                        {% for item in case.ai_analysis.doctor_view.plan_list %}
-                        <li>{{ item | safe }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
+            <div class="col-md-6">
+              <div class="vitals-box">
+                <h6>
+                  <i class="fas fa-prescription-bottle me-2 text-primary"></i>{{
+                  t.doctor_view.meds }}
+                </h6>
+                <p class="mb-0">{{ case.raw_data.current_meds }}</p>
+                <hr class="my-2" />
+                <h6 class="mt-3">
+                  <i class="fas fa-history me-2 text-warning"></i>{{
+                  t.doctor_view.history }}
+                </h6>
+                <p class="mb-0">{{ case.raw_data.history }}</p>
+              </div>
             </div>
+          </div>
 
-            <!-- FOOTER -->
-            <div class="card-footer text-muted small p-4" style="background: #f9fafb; border-top: 2px solid #e5e7eb">
-                <div class="row">
-                    <div class="col-md-6">
-                        <strong>AI-Generated Summary:</strong> MediAssist Clinical
-                        Scribe<br />
-                        <em style="color: #dc2626">⚠️ Requires clinician review before clinical use</em>
-                    </div>
-                    <div class="col-md-6 text-md-end">
-                        <strong>Reviewed by:</strong>
-                        _________________________<br />
-                        <strong>Signature/Date:</strong> _________________________
-                    </div>
-                </div>
+          <hr class="my-5" />
+
+          <!-- SOAP NOTE SECTIONS AS LISTS -->
+
+          <!-- S - SUBJECTIVE -->
+          <div class="soap-section">
+            <span class="soap-label">
+              <i class="fas fa-comment-medical me-2"></i>{{ t.doctor_view.soap_s
+              }}
+            </span>
+            <ul class="soap-list">
+              {% for item in case.ai_analysis.doctor_view.subjective_list %}
+              <li>{{ item | safe }}</li>
+              {% endfor %}
+            </ul>
+            <div class="vitals-box mt-3">
+              <small
+                ><strong>{{ t.doctor_view.duration }}:</strong> {{
+                case.raw_data.duration }}</small
+              ><br />
+              <small
+                ><strong>{{ t.doctor_view.severity }}:</strong> {{
+                case.raw_data.severity }}</small
+              ><br />
+              <small
+                ><strong>{{ t.doctor_view.notes }}:</strong> {{
+                case.raw_data.notes if case.raw_data.notes else 'None' }}</small
+              >
             </div>
+          </div>
+
+          <!-- O - OBJECTIVE -->
+          <div class="soap-section">
+            <span class="soap-label">
+              <i class="fas fa-stethoscope me-2"></i>{{ t.doctor_view.soap_o }}
+            </span>
+            <ul class="soap-list">
+              {% for item in case.ai_analysis.doctor_view.objective_list %}
+              <li>{{ item | safe }}</li>
+              {% endfor %}
+            </ul>
+            <div class="vitals-box mt-3">
+              <small
+                ><strong>{{ t.doctor_view.symptoms }}:</strong> {{
+                case.raw_data.symptoms }}</small
+              >
+            </div>
+          </div>
+
+          <!-- A - ASSESSMENT -->
+          <div class="soap-section">
+            <span class="soap-label">
+              <i class="fas fa-brain me-2"></i>{{ t.doctor_view.soap_a }}
+            </span>
+
+            <!-- Confidence Scores -->
+            {% if case.ai_analysis.doctor_view.possible_conditions %}
+            <div class="mb-4">
+              <h6 class="text-muted mb-3">Diagnostic Confidence:</h6>
+              {% for condition in
+              case.ai_analysis.doctor_view.possible_conditions %}
+              <div class="mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                  <span>{{ condition.name }}</span>
+                  <span class="fw-bold"
+                    >{{ (condition.confidence * 100) | round | int }}%</span
+                  >
+                </div>
+                <div class="progress" style="height: 10px">
+                  <div
+                    class="progress-bar {% if condition.confidence > 0.7 %}bg-success{% elif condition.confidence > 0.4 %}bg-warning{% else %}bg-danger{% endif %}"
+                    role="progressbar"
+                    style="width: {{ condition.confidence * 100 }}%"
+                  ></div>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+            <hr />
+            {% endif %}
+
+            <ul class="soap-list">
+              {% for item in case.ai_analysis.doctor_view.assessment_list %}
+              <li>{{ item | safe }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <!-- P - PLAN -->
+          <div class="soap-section">
+            <span class="soap-label">
+              <i class="fas fa-clipboard-list me-2"></i>{{ t.doctor_view.soap_p
+              }}
+            </span>
+            <ul class="soap-list">
+              {% for item in case.ai_analysis.doctor_view.plan_list %}
+              <li>{{ item | safe }}</li>
+              {% endfor %}
+            </ul>
+          </div>
         </div>
+
+        <!-- FOOTER -->
+        <div
+          class="card-footer text-muted small p-4"
+          style="background: #f9fafb; border-top: 2px solid #e5e7eb"
+        >
+          <div class="row">
+            <div class="col-md-6">
+              <strong>AI-Generated Summary:</strong> MediAssist Clinical
+              Scribe<br />
+              <em style="color: #dc2626"
+                >⚠️ Requires clinician review before clinical use</em
+              >
+            </div>
+            <div class="col-md-6 text-md-end">
+              <strong>Reviewed by:</strong>
+              _________________________<br />
+              <strong>Signature/Date:</strong> _________________________
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,195 +1,380 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>MediAssist by Sneh Thakkar — Clinical AI Assistant</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MediAssist by Sneh Thakkar — Clinical AI Assistant</title>
 
-	<link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
-	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet">
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-	<!-- favicon to avoid broken icon shown by browser -->
-	<link rel="icon" href="{{ url_for('static', filename='img/hospital-plus.svg') }}" type="image/svg+xml">
-</head>
-<body>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <!-- favicon to avoid broken icon shown by browser -->
+    <link
+      rel="icon"
+      href="{{ url_for('static', filename='img/hospital-plus.svg') }}"
+      type="image/svg+xml"
+    />
+  </head>
+  <body>
+    {% include '_settings_popup.html' %}
 
-<nav class="navbar navbar-expand-lg sticky-top">
-	<div class="container">
-		<a class="navbar-brand brand d-flex align-items-center" href="#">
-			<span class="brand-icon me-2" aria-hidden="true" title="MediAssist logo">
-				<!-- inline SVG (keeps crisp rendering and removes external-image problems) -->
-				<svg width="62" height="62" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false">
-					<defs>
-						<linearGradient id="G" x1="0" x2="1" y1="0" y2="1">
-							<stop offset="0%" stop-color="#ff3b30"/>
-							<stop offset="45%" stop-color="#ff7a59"/>
-							<stop offset="100%" stop-color="#8a3ffc"/>
-						</linearGradient>
-						<filter id="innerGlow" x="-50%" y="-50%" width="200%" height="200%">
-							<feGaussianBlur stdDeviation="2.2" result="blur"/>
-							<feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-						</filter>
-					</defs>
-					<rect x="8" y="8" width="84" height="84" rx="14" ry="14" fill="url(#G)" opacity="0.98"/>
-					<g filter="url(#innerGlow)">
-						<path fill="#fff" d="M55 30H45v15H30v10h15v15h10V55h15V45H55z"/>
-					</g>
-				</svg>
-			</span>
-			<span class="brand-text">MediAssist <small class="text-muted">by Sneh Thakkar</small></span>
-		</a>
-		<div class="d-none d-lg-block ms-auto small-muted">One-page clinical assistant • Not a replacement for clinical judgement</div>
-	</div>
-</nav>
+    <nav class="navbar navbar-expand-lg sticky-top">
+      <div class="container">
+        <a class="navbar-brand brand d-flex align-items-center" href="#">
+          <span
+            class="brand-icon me-2"
+            aria-hidden="true"
+            title="MediAssist logo"
+          >
+            <!-- inline SVG (keeps crisp rendering and removes external-image problems) -->
+            <svg
+              width="62"
+              height="62"
+              viewBox="0 0 100 100"
+              xmlns="http://www.w3.org/2000/svg"
+              role="img"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <defs>
+                <linearGradient id="G" x1="0" x2="1" y1="0" y2="1">
+                  <stop offset="0%" stop-color="#ff3b30" />
+                  <stop offset="45%" stop-color="#ff7a59" />
+                  <stop offset="100%" stop-color="#8a3ffc" />
+                </linearGradient>
+                <filter
+                  id="innerGlow"
+                  x="-50%"
+                  y="-50%"
+                  width="200%"
+                  height="200%"
+                >
+                  <feGaussianBlur stdDeviation="2.2" result="blur" />
+                  <feMerge>
+                    <feMergeNode in="blur" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
+              </defs>
+              <rect
+                x="8"
+                y="8"
+                width="84"
+                height="84"
+                rx="14"
+                ry="14"
+                fill="url(#G)"
+                opacity="0.98"
+              />
+              <g filter="url(#innerGlow)">
+                <path
+                  fill="#fff"
+                  d="M55 30H45v15H30v10h15v15h10V55h15V45H55z"
+                />
+              </g>
+            </svg>
+          </span>
+          <span class="brand-text"
+            >MediAssist <small class="text-muted">by Sneh Thakkar</small></span
+          >
+        </a>
+        <div class="d-none d-lg-block ms-auto small-muted">
+          One-page clinical assistant • Not a replacement for clinical judgement
+        </div>
+      </div>
+    </nav>
 
-<div class="container my-5">
-	<div class="row g-4">
-		<div class="col-lg-12">
-			<!-- simplified title / hero — removed status banner -->
-			<div class="hero d-flex flex-column flex-md-row align-items-start justify-content-between">
-				<div>
-					<h1 class="mb-1">MediAssist — Clinical AI Assistant</h1>
-					<p class="lead mb-0 small-muted">Concise clinical summaries and suggested treatment plans. Educational prototype — not a substitute for clinical judgement.</p>
-				</div>
-				<div class="text-end d-none d-sm-block ms-3"></div>
-			</div>
-		</div>
+    <div class="container my-5">
+      <div class="row g-4">
+        <div class="col-lg-12">
+          <!-- simplified title / hero — removed status banner -->
+          <div
+            class="hero d-flex flex-column flex-md-row align-items-start justify-content-between"
+          >
+            <div>
+              <h1 class="mb-1">MediAssist — Clinical AI Assistant</h1>
+              <p class="lead mb-0 small-muted">
+                Concise clinical summaries and suggested treatment plans.
+                Educational prototype — not a substitute for clinical judgement.
+              </p>
+            </div>
+            <div class="text-end d-none d-sm-block ms-3"></div>
+          </div>
+        </div>
 
-		<!-- centered single-column layout for the intake form -->
-		<div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
-			<div class="form-card">
-				<h4 class="mb-3 title-with-icon"><i class="fas fa-notes-medical me-2 icon-muted"></i>Patient Intake</h4>
+        <!-- centered single-column layout for the intake form -->
+        <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
+          <div class="form-card">
+            <h4 class="mb-3 title-with-icon">
+              <i class="fas fa-notes-medical me-2 icon-muted"></i>Patient Intake
+            </h4>
 
-				<form id="intake" action="/diagnose" method="POST" novalidate>
-					<!-- Row 1 -->
-					<div class="row g-3">
-						<div class="col-sm-6">
-							<label class="form-label">Full name</label>
-							<input type="text" name="name" class="form-control" placeholder="e.g., Priya Patel">
-						</div>
-						<div class="col-sm-3">
-							<label class="form-label">Age <span class="req">*</span></label>
-							<input type="number" name="age" class="form-control" placeholder="Years" min="0" required>
-						</div>
-						<div class="col-sm-3">
-							<label class="form-label">Gender</label>
-							<select name="gender" class="form-select">
-								<option>Prefer not to say</option>
-								<option>Female</option>
-								<option>Male</option>
-								<option>Other</option>
-							</select>
-						</div>
+            <form id="intake" action="/diagnose" method="POST" novalidate>
+              <!-- Row 1 -->
+              <div class="row g-3">
+                <div class="col-sm-6">
+                  <label class="form-label">Full name</label>
+                  <input
+                    type="text"
+                    name="name"
+                    class="form-control"
+                    placeholder="e.g., Priya Patel"
+                  />
+                </div>
+                <div class="col-sm-3">
+                  <label class="form-label"
+                    >Age <span class="req">*</span></label
+                  >
+                  <input
+                    type="number"
+                    name="age"
+                    class="form-control"
+                    placeholder="Years"
+                    min="0"
+                    required
+                  />
+                </div>
+                <div class="col-sm-3">
+                  <label class="form-label">Gender</label>
+                  <select name="gender" class="form-select">
+                    <option>Prefer not to say</option>
+                    <option>Female</option>
+                    <option>Male</option>
+                    <option>Other</option>
+                  </select>
+                </div>
 
-						<!-- Row 2 -->
-						<div class="col-sm-4">
-							<label class="form-label">Weight (kg)</label>
-							<input type="number" step="0.1" name="weight" class="form-control" placeholder="e.g., 68">
-						</div>
-						<div class="col-sm-4">
-							<label class="form-label">Height (cm)</label>
-							<input type="number" step="0.1" name="height" class="form-control" placeholder="e.g., 170">
-						</div>
-						<div class="col-sm-4">
-							<label class="form-label">Temperature (°C)</label>
-							<input type="number" step="0.1" name="temperature" class="form-control" placeholder="e.g., 38.2">
-						</div>
+                <!-- Row 2 -->
+                <div class="col-sm-4">
+                  <label class="form-label">Weight (kg)</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    name="weight"
+                    class="form-control"
+                    placeholder="e.g., 68"
+                  />
+                </div>
+                <div class="col-sm-4">
+                  <label class="form-label">Height (cm)</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    name="height"
+                    class="form-control"
+                    placeholder="e.g., 170"
+                  />
+                </div>
+                <div class="col-sm-4">
+                  <label class="form-label">Temperature (°C)</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    name="temperature"
+                    class="form-control"
+                    placeholder="e.g., 38.2"
+                  />
+                </div>
 
-						<!-- Row 3 -->
-						<div class="col-6">
-							<label class="form-label">Blood Pressure (optional)</label>
-							<input type="text" name="blood_pressure" class="form-control" placeholder="e.g., 120/80">
-						</div>
-						<div class="col-6">
-							<label class="form-label">Symptom onset / duration <span class="req">*</span></label>
-							<input type="text" name="duration" class="form-control" placeholder="e.g., 3 days, sudden" required>
-						</div>
+                <!-- Row 3 -->
+                <div class="col-6">
+                  <label class="form-label">Blood Pressure (optional)</label>
+                  <input
+                    type="text"
+                    name="blood_pressure"
+                    class="form-control"
+                    placeholder="e.g., 120/80"
+                  />
+                </div>
+                <div class="col-6">
+                  <label class="form-label"
+                    >Symptom onset / duration <span class="req">*</span></label
+                  >
+                  <input
+                    type="text"
+                    name="duration"
+                    class="form-control"
+                    placeholder="e.g., 3 days, sudden"
+                    required
+                  />
+                </div>
 
-						<!-- Row 4 -->
-						<div class="col-md-6">
-							<label class="form-label">Allergies <span class="req">*</span></label>
-							<input type="text" name="allergies" class="form-control" placeholder="e.g., Penicillin, NKDA" required>
-						</div>
-						<div class="col-md-6">
-							<label class="form-label">Current medications <span class="req">*</span></label>
-							<input type="text" name="current_medications" class="form-control" placeholder="e.g., Metformin 500mg, Lisinopril 5mg" required>
-						</div>
+                <!-- Row 4 -->
+                <div class="col-md-6">
+                  <label class="form-label"
+                    >Allergies <span class="req">*</span></label
+                  >
+                  <input
+                    type="text"
+                    name="allergies"
+                    class="form-control"
+                    placeholder="e.g., Penicillin, NKDA"
+                    required
+                  />
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label"
+                    >Current medications <span class="req">*</span></label
+                  >
+                  <input
+                    type="text"
+                    name="current_medications"
+                    class="form-control"
+                    placeholder="e.g., Metformin 500mg, Lisinopril 5mg"
+                    required
+                  />
+                </div>
 
-						<!-- Row 5 -->
-						<div class="col-12">
-							<label class="form-label">Past medical history (brief)</label>
-							<input type="text" name="medical_history" class="form-control" placeholder="e.g., Asthma, Type-2 diabetes, surgeries">
-						</div>
+                <!-- Row 5 -->
+                <div class="col-12">
+                  <label class="form-label">Past medical history (brief)</label>
+                  <input
+                    type="text"
+                    name="medical_history"
+                    class="form-control"
+                    placeholder="e.g., Asthma, Type-2 diabetes, surgeries"
+                  />
+                </div>
 
-						<!-- Row 6 -->
-						<div class="col-12">
-							<label class="form-label">Severity</label>
-							<select name="severity" class="form-select">
-								<option>Mild</option>
-								<option selected>Moderate</option>
-								<option>Severe</option>
-							</select>
-						</div>
+                <!-- Row 6 -->
+                <div class="col-12">
+                  <label class="form-label">Severity</label>
+                  <select name="severity" class="form-select">
+                    <option>Mild</option>
+                    <option selected>Moderate</option>
+                    <option>Severe</option>
+                  </select>
+                </div>
 
-						<div class="col-12">
-							<label class="form-label">Clinical Symptoms <span class="req">*</span></label>
-							<textarea name="symptoms" class="form-control" rows="5" placeholder="Describe the symptoms in detail... (e.g., high fever, severe headache, nausea) — include red flags you noticed" required></textarea>
-							<div class="small-muted mt-1">Try to be as specific as possible — this improves suggestions.</div>
-						</div>
+                <div class="col-12">
+                  <label class="form-label"
+                    >Clinical Symptoms <span class="req">*</span></label
+                  >
+                  <textarea
+                    name="symptoms"
+                    class="form-control"
+                    rows="5"
+                    placeholder="Describe the symptoms in detail... (e.g., high fever, severe headache, nausea) — include red flags you noticed"
+                    required
+                  ></textarea>
+                  <div class="small-muted mt-1">
+                    Try to be as specific as possible — this improves
+                    suggestions.
+                  </div>
+                </div>
 
-						<div class="col-12">
-							<label class="form-label">Any other notes (exposures, recent travel, COVID status)</label>
-							<input type="text" name="other_notes" class="form-control" placeholder="optional">
-						</div>
+                <div class="col-12">
+                  <label class="form-label"
+                    >Any other notes (exposures, recent travel, COVID
+                    status)</label
+                  >
+                  <input
+                    type="text"
+                    name="other_notes"
+                    class="form-control"
+                    placeholder="optional"
+                  />
+                </div>
 
-						<div class="col-12">
-							<div class="form-check">
-								<input class="form-check-input" type="checkbox" value="1" id="confirm" name="confirm" required>
-								<label class="form-check-label small-muted" for="confirm">I confirm the information above is accurate to the best of my knowledge. I understand this is an AI-run prototype and not a definitive medical diagnosis.</label>
-							</div>
-						</div>
+                <div class="col-12">
+                  <div class="form-check">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      value="1"
+                      id="confirm"
+                      name="confirm"
+                      required
+                    />
+                    <label class="form-check-label small-muted" for="confirm"
+                      >I confirm the information above is accurate to the best
+                      of my knowledge. I understand this is an AI-run prototype
+                      and not a definitive medical diagnosis.</label
+                    >
+                  </div>
+                </div>
 
-						<div class="col-12 text-center mt-3">
-							<button id="submitBtn" type="submit" class="btn-medical btn w-100">
-								<span id="btnLabel"><i class="fas fa-stethoscope me-2"></i>Analyze & Generate Plan</span>
-								<span id="btnSpinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"></span>
-							</button>
-						</div>
+                <div class="col-12 text-center mt-3">
+                  <button
+                    id="submitBtn"
+                    type="submit"
+                    class="btn-medical btn w-100"
+                  >
+                    <span id="btnLabel"
+                      ><i class="fas fa-stethoscope me-2"></i>Analyze & Generate
+                      Plan</span
+                    >
+                    <span
+                      id="btnSpinner"
+                      class="spinner-border spinner-border-sm ms-2 d-none"
+                      role="status"
+                      aria-hidden="true"
+                    ></span>
+                  </button>
+                </div>
 
-						<div class="col-12 small-muted text-center mt-3">
-							<small><strong>Note:</strong> For safety, allergies & current medications are required to provide prescriptions.</small>
-						</div>
-					</div>
-				</form>
-			</div>
+                <div class="col-12 small-muted text-center mt-3">
+                  <small
+                    ><strong>Note:</strong> For safety, allergies & current
+                    medications are required to provide prescriptions.</small
+                  >
+                </div>
+              </div>
+            </form>
+          </div>
 
-			<!-- error (AJAX) shown below form -->
-			<div id="errorArea" class="mt-4" aria-live="polite" role="status"></div>
-		</div>
+          <!-- error (AJAX) shown below form -->
+          <div
+            id="errorArea"
+            class="mt-4"
+            aria-live="polite"
+            role="status"
+          ></div>
+        </div>
 
-		<!-- results row: patient summary and AI assessment stacked under the form -->
-		<div class="col-12">
-			<div class="stacked-results mt-4">
-				<div id="patientSummaryContainer"></div>
-				<div id="aiResultContainer">
-					<div class="result-box small-muted">
-						<h6 class="text-muted"><i class="fas fa-info-circle me-2"></i> How it works</h6>
-						<p class="mb-0">Fill the intake above and confirm. MediAssist will generate a patient-friendly explanation and a suggested treatment plan. This is educational only.</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+        <!-- results row: patient summary and AI assessment stacked under the form -->
+        <div class="col-12">
+          <div class="stacked-results mt-4">
+            <div id="patientSummaryContainer"></div>
+            <div id="aiResultContainer">
+              <div class="result-box small-muted">
+                <h6 class="text-muted">
+                  <i class="fas fa-info-circle me-2"></i> How it works
+                </h6>
+                <p class="mb-0">
+                  Fill the intake above and confirm. MediAssist will generate a
+                  patient-friendly explanation and a suggested treatment plan.
+                  This is educational only.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-	<div class="footer mt-5">
-		<hr>
-		<small>MediAssist by Sneh Thakkar • Prototype / Educational use only • <em>Do not use for emergencies</em></small>
-	</div>
-</div>
+      <div class="footer mt-5">
+        <hr />
+        <small
+          >MediAssist by Sneh Thakkar • Prototype / Educational use only •
+          <em>Do not use for emergencies</em></small
+        >
+      </div>
+    </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="{{ url_for('static', filename='js/app.js') }}"></script>
-
-</body>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  </body>
 </html>

--- a/templates/intake.html
+++ b/templates/intake.html
@@ -29,6 +29,8 @@
     </style>
   </head>
   <body>
+    {% include '_settings_popup.html' %}
+
     <!-- NAVBAR -->
     <nav class="navbar">
       <div class="container">
@@ -40,7 +42,6 @@
           >
         </a>
         <div class="d-flex gap-2 align-items-center">
-          {% include '_language_toggle.html' %}
           <a href="/cases" class="btn btn-outline-secondary btn-sm">
             <i class="fas fa-folder-open me-1"></i> {{ t.common.all_records }}
           </a>
@@ -316,5 +317,6 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -12,6 +12,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
       body {
         background: linear-gradient(135deg, #e3f2fd 0%, #f0f4f8 100%);
@@ -20,6 +24,10 @@
         justify-content: center;
         min-height: 100vh;
         font-family: "Inter", sans-serif;
+        transition: background 0.3s ease;
+      }
+      [data-theme="dark"] body {
+        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
       }
       .hero-container {
         text-align: center;
@@ -94,10 +102,9 @@
     </style>
   </head>
   <body>
+    {% include '_settings_popup.html' %}
+
     <div class="container">
-      <div class="d-flex justify-content-end mb-3">
-        {% include '_language_toggle.html' %}
-      </div>
       <div class="hero-container">
         <h1><i class="fas fa-heartbeat me-2"></i>{{ t.common.app_name }}</h1>
         <p>{{ t.landing.subtitle }}</p>
@@ -149,5 +156,6 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/patient_login.html
+++ b/templates/patient_login.html
@@ -12,12 +12,21 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
       body {
         background: linear-gradient(135deg, #e3f2fd 0%, #f0f4f8 100%);
         display: flex;
         align-items: center;
         justify-content: center;
+        transition: background 0.3s ease;
+      }
+      [data-theme="dark"] body {
+        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      }
         min-height: 100vh;
         font-family: "Inter", sans-serif;
       }
@@ -94,9 +103,8 @@
     </style>
   </head>
   <body>
-    <div style="position: fixed; top: 20px; right: 20px; z-index: 1000">
-      {% include '_language_toggle.html' %}
-    </div>
+    {% include '_settings_popup.html' %}
+
     <div class="login-card">
       <div class="login-header">
         <h2>
@@ -161,5 +169,6 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/patient_result.html
+++ b/templates/patient_result.html
@@ -18,6 +18,8 @@
     />
   </head>
   <body>
+    {% include '_settings_popup.html' %}
+
     <!-- NAVBAR -->
     <nav class="navbar">
       <div class="container">
@@ -29,7 +31,6 @@
           >
         </a>
         <div class="d-flex gap-2 align-items-center">
-          {% include '_language_toggle.html' %}
           <a href="/cases" class="btn btn-outline-secondary btn-sm">
             <i class="fas fa-folder-open me-1"></i>{{ t.common.all_records }}
           </a>
@@ -163,5 +164,6 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   </body>
 </html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,98 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Create Account | MediAssist</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
     <style>
-        /* Define theme classes based on the role */
-        .bg-patient { background: linear-gradient(135deg, #e3f2fd 0%, #f0f4f8 100%); }
-        .bg-doctor { background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%); }
-        .text-patient { color: #0052cc; }
-        .text-doctor { color: #7b1fa2; }
-        .btn-patient { background: linear-gradient(135deg, #0052cc 0%, #003d99 100%); color: white; border: none; }
-        .btn-doctor { background: linear-gradient(135deg, #7b1fa2 0%, #5e35b1 100%); color: white; border: none; }
-        .btn-theme:hover { transform: translateY(-2px); color: white; }
+      /* Define theme classes based on the role */
+      .bg-patient {
+        background: linear-gradient(135deg, #e3f2fd 0%, #f0f4f8 100%);
+      }
+      .bg-doctor {
+        background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
+      }
+      [data-theme="dark"] .bg-patient {
+        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      }
+      [data-theme="dark"] .bg-doctor {
+        background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+      }
+      .text-patient {
+        color: #0052cc;
+      }
+      .text-doctor {
+        color: #7b1fa2;
+      }
+      .btn-patient {
+        background: linear-gradient(135deg, #0052cc 0%, #003d99 100%);
+        color: white;
+        border: none;
+      }
+      .btn-doctor {
+        background: linear-gradient(135deg, #7b1fa2 0%, #5e35b1 100%);
+        color: white;
+        border: none;
+      }
+      .btn-theme:hover {
+        transform: translateY(-2px);
+        color: white;
+      }
 
-        body {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
-            font-family: 'Inter', sans-serif;
-            padding: 2rem 0;
-        }
-        .login-card {
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 8px 24px rgba(0,0,0,0.12);
-            border: 1px solid #e5e7eb;
-            padding: 2.5rem;
-            max-width: 450px;
-            width: 100%;
-        }
-        .form-control { border-radius: 8px; padding: 0.7rem 1rem; }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        font-family: "Inter", sans-serif;
+        padding: 2rem 0;
+      }
+      .login-card {
+        background: white;
+        border-radius: 16px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+        border: 1px solid #e5e7eb;
+        padding: 2.5rem;
+        max-width: 450px;
+        width: 100%;
+      }
+      .form-control {
+        border-radius: 8px;
+        padding: 0.7rem 1rem;
+      }
     </style>
-</head>
-<body class="{% if role == 'patient' %}bg-patient{% else %}bg-doctor{% endif %}">
+  </head>
+  <body
+    class="{% if role == 'patient' %}bg-patient{% else %}bg-doctor{% endif %}"
+  >
+    {% include '_settings_popup.html' %}
+
     <div class="login-card">
-        <div class="text-center mb-4">
-            <h2 class="{% if role == 'patient' %}text-patient{% else %}text-doctor{% endif %} fw-bold">
-                <i class="fas {% if role == 'patient' %}fa-user-plus{% else %}fa-user-md{% endif %} me-2"></i>
-                New {{ role|capitalize }} Account
-            </h2>
-            <p class="text-muted">Join the MediAssist Platform</p>
+      <div class="text-center mb-4">
+        <h2
+          class="{% if role == 'patient' %}text-patient{% else %}text-doctor{% endif %} fw-bold"
+        >
+          <i
+            class="fas {% if role == 'patient' %}fa-user-plus{% else %}fa-user-md{% endif %} me-2"
+          ></i>
+          New {{ role|capitalize }} Account
+        </h2>
+        <p class="text-muted">Join the MediAssist Platform</p>
+      </div>
+
+      {% with messages = get_flashed_messages(category_filter=['danger']) %} {%
+      if messages %}
+      <div class="alert alert-danger small py-2">{{ messages[0] }}</div>
+      {% endif %} {% endwith %}
+
+      <form method="POST">
+        <div class="mb-3">
+          <label class="form-label fw-bold small text-muted">Full Name</label>
+          <input
+            type="text"
+            name="name"
+            class="form-control"
+            placeholder="e.g. John Doe"
+            required
+          />
         </div>
 
-        {% with messages = get_flashed_messages(category_filter=['danger']) %}
-            {% if messages %}
-                <div class="alert alert-danger small py-2">{{ messages[0] }}</div>
-            {% endif %}
-        {% endwith %}
-
-        <form method="POST">
-            <div class="mb-3">
-                <label class="form-label fw-bold small text-muted">Full Name</label>
-                <input type="text" name="name" class="form-control" placeholder="e.g. John Doe" required>
-            </div>
-            
-            <div class="mb-3">
-                <label class="form-label fw-bold small text-muted">Username</label>
-                <input type="text" name="username" class="form-control" placeholder="Choose a login ID" required>
-            </div>
-
-            <div class="mb-3">
-                <label class="form-label fw-bold small text-muted">Password</label>
-                <input type="password" name="password" class="form-control" placeholder="Create a password" required>
-            </div>
-
-            <!-- Doctor Specific Fields -->
-            {% if role == 'doctor' %}
-            <div class="p-3 bg-light rounded border mb-3">
-                <h6 class="text-doctor border-bottom pb-2 mb-3 small fw-bold">Physician Verification</h6>
-                <div class="mb-3">
-                    <label class="form-label small">Medical License ID</label>
-                    <input type="text" name="doctor_id" class="form-control form-control-sm" placeholder="e.g. DOC-55123" required>
-                    <div class="form-text small">Must start with 'DOC-'</div>
-                </div>
-                <div class="mb-0">
-                    <label class="form-label small">Specialty</label>
-                    <input type="text" name="specialty" class="form-control form-control-sm" placeholder="e.g. Cardiology" required>
-                </div>
-            </div>
-            {% endif %}
-
-            <button type="submit" class="btn {% if role == 'patient' %}btn-patient{% else %}btn-doctor{% endif %} btn-theme mt-3">
-                Create Account
-            </button>
-        </form>
-
-        <div class="text-center mt-4 border-top pt-3">
-            <small class="text-muted">Already have an account?</small><br>
-            <a href="/{{ role }}/login" class="{% if role == 'patient' %}text-patient{% else %}text-doctor{% endif %} fw-bold text-decoration-none">Login Here</a>
+        <div class="mb-3">
+          <label class="form-label fw-bold small text-muted">Username</label>
+          <input
+            type="text"
+            name="username"
+            class="form-control"
+            placeholder="Choose a login ID"
+            required
+          />
         </div>
+
+        <div class="mb-3">
+          <label class="form-label fw-bold small text-muted">Password</label>
+          <input
+            type="password"
+            name="password"
+            class="form-control"
+            placeholder="Create a password"
+            required
+          />
+        </div>
+
+        <!-- Doctor Specific Fields -->
+        {% if role == 'doctor' %}
+        <div class="p-3 bg-light rounded border mb-3">
+          <h6 class="text-doctor border-bottom pb-2 mb-3 small fw-bold">
+            Physician Verification
+          </h6>
+          <div class="mb-3">
+            <label class="form-label small">Medical License ID</label>
+            <input
+              type="text"
+              name="doctor_id"
+              class="form-control form-control-sm"
+              placeholder="e.g. DOC-55123"
+              required
+            />
+            <div class="form-text small">Must start with 'DOC-'</div>
+          </div>
+          <div class="mb-0">
+            <label class="form-label small">Specialty</label>
+            <input
+              type="text"
+              name="specialty"
+              class="form-control form-control-sm"
+              placeholder="e.g. Cardiology"
+              required
+            />
+          </div>
+        </div>
+        {% endif %}
+
+        <button
+          type="submit"
+          class="btn {% if role == 'patient' %}btn-patient{% else %}btn-doctor{% endif %} btn-theme mt-3"
+        >
+          Create Account
+        </button>
+      </form>
+
+      <div class="text-center mt-4 border-top pt-3">
+        <small class="text-muted">Already have an account?</small><br />
+        <a
+          href="/{{ role }}/login"
+          class="{% if role == 'patient' %}text-patient{% else %}text-doctor{% endif %} fw-bold text-decoration-none"
+          >Login Here</a
+        >
+      </div>
     </div>
-</body>
+
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  </body>
 </html>


### PR DESCRIPTION
This pull request resolves the issue #13 

It introduces a comprehensive dark mode feature and a new floating settings popup to the application, improving user experience and accessibility. 

The changes include new CSS variables for theming, dark mode-specific styles, JavaScript logic for theme persistence and toggling, and integration of a settings popup for easy access to appearance and language settings. These enhancements are applied across major templates to ensure consistency.

**Dark Mode & Theming Enhancements**
* Added extensive CSS variables for background, text, and border colors, and defined a full dark mode palette using the `[data-theme="dark"]` attribute in `static/css/styles.css`. This enables dynamic theme switching and component-specific overrides for dark mode.
* Updated body styling to use new theme variables for color and background, with smooth transitions for theme changes.

**Settings Popup & UI Integration**
* Introduced a floating settings button (`settings-fab`) and a popup panel (`settings-popup`) with theme and language toggles, implemented in `templates/_settings_popup.html` and styled in `static/css/styles.css`.

<div align="center">
<img width="650" alt="image" src="https://github.com/user-attachments/assets/d4bf3fac-2c52-42af-b96f-4b566b31672a" />
</div

**JavaScript Functionality**
* Added logic in `static/js/app.js` to initialize theme from localStorage or system preference, handle theme toggling, update theme icons, and manage the settings popup's visibility and accessibility.

**Template Updates**
* Ensured all major templates load the new CSS and JS files and removed redundant language toggle from navbar, consolidating it within the settings popup for a cleaner UI.